### PR TITLE
support: Use bzip2 instead of gzip in "mariadb-backup"

### DIFF
--- a/apps/mariadb-backup/src/backup.ts
+++ b/apps/mariadb-backup/src/backup.ts
@@ -31,7 +31,7 @@ class MariaDBBackupCommand extends BackupCommand {
     logger.info(`backup ${dbDumpFilePath}...`);
     logger.info('dump MariaDB...');
     const { stdout, stderr } = await exec(
-      `set -o pipefail; mysqldump ${options.backupToolOptions} | gzip > ${dbDumpFilePath}`,
+      `set -o pipefail; mysqldump ${options.backupToolOptions} | bzip2 > ${dbDumpFilePath}`,
       { shell: '/bin/bash' },
     );
     return { stdout, stderr, dbDumpFilePath };


### PR DESCRIPTION
- Use bzip2 instead of gzip in "mariadb-backup"