### PR TITLE
fix: File extension of "mariadb-backup" is wrong

### DIFF
--- a/apps/mariadb-backup/src/backup.ts
+++ b/apps/mariadb-backup/src/backup.ts
@@ -26,7 +26,7 @@ class MariaDBBackupCommand extends BackupCommand {
   async dumpDB(options: IBackupCommandOption):
       Promise<{ stdout: string, stderr: string, dbDumpFilePath: string }> {
     const tmpdir = tmp.dirSync({ unsafeCleanup: true });
-    const dbDumpFilePath = join(tmpdir.name, `${options.backupfilePrefix}-${format(Date.now(), 'yyyyMMddHHmmss')}.gz`);
+    const dbDumpFilePath = join(tmpdir.name, `${options.backupfilePrefix}-${format(Date.now(), 'yyyyMMddHHmmss')}.bz2`);
 
     logger.info(`backup ${dbDumpFilePath}...`);
     logger.info('dump MariaDB...');


### PR DESCRIPTION
- fix file name of "mariadb-backup" command