### PR TITLE
fix: Extracting archive logic of restore command is wrong

### DIFF
--- a/packages/commands/src/commands/restore.ts
+++ b/packages/commands/src/commands/restore.ts
@@ -60,9 +60,8 @@ export class RestoreCommand extends StorageServiceClientCommand {
 
       newBackupFilePath = newBackupFilePath.slice(0, -ext.length);
     }
-    // If Writable stream does not exist, add it.
-    const lastStream = streams.at(-1) as WriteStream;
-    if (lastStream?.writable === false) {
+    // If last stream is not of '.tar', add file writing stream.
+    if (streams.at(-1) !== processors['.tar']) {
       streams.push(createWriteStream(newBackupFilePath));
     }
 


### PR DESCRIPTION
* Fix extracting archive logic of restore command (#46 is wrong also)