### PR TITLE
support: Fix document about GCS authentication

### DIFF
--- a/apps/list/README.md
+++ b/apps/list/README.md
@@ -30,6 +30,8 @@ S3 or GCS authentication is required depending on the storage service used.
 
 - For S3
   - Set `AWS_REGION` and `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
-- For GCS
-  - To use [service account authentication](https://cloud.google.com/docs/authentication/production), create JSON Web Key and set `GCP_SERVICE_JSON_PATH` and `GCP_PROJECT_ID`
-  - To use [HMAC authentication](https://cloud.google.com/storage/docs/authentication/hmackeys), set `GCP_ACCESS_KEY_ID`, `GCP_SECRET_ACCESS_KEY`, and `GCP_PROJECT_ID`
+- For GCS(*)
+  - Set `GCP_SERVICE_JSON_PATH`, or `GCP_CLIENT_EMAIL` and `GCP_PRIVATE_KEY`.  
+    For detail, see [service account authentication](https://cloud.google.com/docs/authentication/production).
+
+(*) You can't use HMAC authentication to authenticate GCS. (https://github.com/googleapis/nodejs-storage/issues/117)

--- a/apps/mariadb-backup/README.md
+++ b/apps/mariadb-backup/README.md
@@ -37,9 +37,11 @@ S3 or GCS authentication is required depending on the storage service used.
 
 - For S3
   - Set `AWS_REGION` and `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
-- For GCS
-  - To use [service account authentication](https://cloud.google.com/docs/authentication/production), create JSON Web Key and set `GCP_SERVICE_JSON_PATH` and `GCP_PROJECT_ID`
-  - To use [HMAC authentication](https://cloud.google.com/storage/docs/authentication/hmackeys), set `GCP_ACCESS_KEY_ID`, `GCP_SECRET_ACCESS_KEY`, and `GCP_PROJECT_ID`
+- For GCS(*)
+  - Set `GCP_SERVICE_JSON_PATH`, or `GCP_CLIENT_EMAIL` and `GCP_PRIVATE_KEY`.  
+    For detail, see [service account authentication](https://cloud.google.com/docs/authentication/production).
+
+(*) You can't use HMAC authentication to authenticate GCS. (https://github.com/googleapis/nodejs-storage/issues/117)
 
 ## Migrate from [weseek/mariadb-awesome-backup](https://github.com/weseek/mariadb-awesome-backup)
 
@@ -47,13 +49,18 @@ Change the following environment variables.
 
 | weseek/mariadb-awesome-backup | mariadb-backup |
 | ----------------------------- | -------------- |
-| `GCP_ACCESS_KEY_ID` | `GCP_CLIENT_EMAIL` |
-| `GCP_SECRET_ACCESS_KEY` | `GCP_PRIVATE_KEY` |
 | `MARIADB_HOST` | `BACKUP_TOOL_OPTIONS` |
 | `MARIADB_DBNAME` | `BACKUP_TOOL_OPTIONS` |
 | `MARIADB_USERNAME` | `BACKUP_TOOL_OPTIONS` |
 | `MARIADB_PASSWORD` | `BACKUP_TOOL_OPTIONS` or `MYSQL_PWD` |
 | `MYSQLDUMP_OPTS` | `BACKUP_TOOL_OPTIONS` |
+
+### Use service account authentication
+
+You can't use HMAC authentication to authenticate GCS. (https://github.com/googleapis/nodejs-storage/issues/117)
+
+So, you need to use [service account authentication](https://cloud.google.com/docs/authentication/production).
+Set `GCP_SERVICE_JSON_PATH`, or `GCP_CLIENT_EMAIL` and `GCP_PRIVATE_KEY`.
 
 ### Set proper timezone
 

--- a/apps/mariadb-restore/README.md
+++ b/apps/mariadb-restore/README.md
@@ -37,9 +37,11 @@ S3 or GCS authentication is required depending on the storage service used.
 
 - For S3
   - Set `AWS_REGION` and `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
-- For GCS
-  - To use [service account authentication](https://cloud.google.com/docs/authentication/production), create JSON Web Key and set `GCP_SERVICE_JSON_PATH` and `GCP_PROJECT_ID`
-  - To use [HMAC authentication](https://cloud.google.com/storage/docs/authentication/hmackeys), set `GCP_ACCESS_KEY_ID`, `GCP_SECRET_ACCESS_KEY`, and `GCP_PROJECT_ID`
+- For GCS(*)
+  - Set `GCP_SERVICE_JSON_PATH`, or `GCP_CLIENT_EMAIL` and `GCP_PRIVATE_KEY`.  
+    For detail, see [service account authentication](https://cloud.google.com/docs/authentication/production).
+
+(*) You can't use HMAC authentication to authenticate GCS. (https://github.com/googleapis/nodejs-storage/issues/117)
 
 ## Migrate from [weseek/mariadb-awesome-backup](https://github.com/weseek/mariadb-awesome-backup)
 
@@ -47,13 +49,18 @@ Change the following environment variables.
 
 | weseek/mariadb-awesome-backup | mariadb-restore |
 | ----------------------------- | -------------- |
-| `GCP_ACCESS_KEY_ID` | `GCP_CLIENT_EMAIL` |
-| `GCP_SECRET_ACCESS_KEY` | `GCP_PRIVATE_KEY` |
 | `MARIADB_HOST` | `RESTORE_TOOL_OPTIONS` |
 | `MARIADB_DBNAME` | `RESTORE_TOOL_OPTIONS` |
 | `MARIADB_USERNAME` | `RESTORE_TOOL_OPTIONS` |
 | `MARIADB_PASSWORD` | `RESTORE_TOOL_OPTIONS` or `MYSQL_PWD` |
 | `MYSQL_OPTS` | `RESTORE_TOOL_OPTIONS` |
+
+### Use service account authentication
+
+You can't use HMAC authentication to authenticate GCS. (https://github.com/googleapis/nodejs-storage/issues/117)
+
+So, you need to use [service account authentication](https://cloud.google.com/docs/authentication/production).
+Set `GCP_SERVICE_JSON_PATH`, or `GCP_CLIENT_EMAIL` and `GCP_PRIVATE_KEY`.
 
 ### Set proper timezone
 

--- a/apps/mongodb-backup/README.md
+++ b/apps/mongodb-backup/README.md
@@ -37,9 +37,11 @@ S3 or GCS authentication is required depending on the storage service used.
 
 - For S3
   - Set `AWS_REGION` and `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
-- For GCS
-  - To use [service account authentication](https://cloud.google.com/docs/authentication/production), create JSON Web Key and set `GCP_SERVICE_JSON_PATH` and `GCP_PROJECT_ID`
-  - To use [HMAC authentication](https://cloud.google.com/storage/docs/authentication/hmackeys), set `GCP_ACCESS_KEY_ID`, `GCP_SECRET_ACCESS_KEY`, and `GCP_PROJECT_ID`
+- For GCS(*)
+  - Set `GCP_SERVICE_JSON_PATH`, or `GCP_CLIENT_EMAIL` and `GCP_PRIVATE_KEY`.  
+    For detail, see [service account authentication](https://cloud.google.com/docs/authentication/production).
+
+(*) You can't use HMAC authentication to authenticate GCS. (https://github.com/googleapis/nodejs-storage/issues/117)
 
 # Migrate from [weseek/mongodb-awesome-backup](https://github.com/weseek/mongodb-awesome-backup)
 
@@ -48,8 +50,6 @@ Change the following environment variables.
 | weseek/mongodb-awesome-backup | mongodb-backup |
 | ----------------------------- | -------------- |
 | `AWSCLI_ENDPOINT_OPT` | `AWS_ENDPOINT_URL` |
-| `GCP_ACCESS_KEY_ID` | `GCP_CLIENT_EMAIL` |
-| `GCP_SECRET_ACCESS_KEY` | `GCP_PRIVATE_KEY` |
 | `MONGODB_URI` | `BACKUP_TOOL_OPTIONS` |
 | `MONGODB_HOST` | `BACKUP_TOOL_OPTIONS` |
 | `MONGODB_DBNAME` | `BACKUP_TOOL_OPTIONS` |
@@ -59,6 +59,13 @@ Change the following environment variables.
 | `CRONMODE` | - **NO SETTINGS REQURIED** (Only `CRON_EXPRESSION` needs to be set) |
 | `AWSCLIOPT` | - **DISABLED** |
 | `GCSCLIOPT` | - **DISABLED** |
+
+### Use service account authentication
+
+You can't use HMAC authentication to authenticate GCS. (https://github.com/googleapis/nodejs-storage/issues/117)
+
+So, you need to use [service account authentication](https://cloud.google.com/docs/authentication/production).
+Set `GCP_SERVICE_JSON_PATH`, or `GCP_CLIENT_EMAIL` and `GCP_PRIVATE_KEY`.
 
 ### Set proper timezone
 

--- a/apps/mongodb-restore/README.md
+++ b/apps/mongodb-restore/README.md
@@ -34,9 +34,11 @@ S3 or GCS authentication is required depending on the storage service used.
 
 - For S3
   - Set `AWS_REGION` and `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
-- For GCS
-  - To use [service account authentication](https://cloud.google.com/docs/authentication/production), create JSON Web Key and set `GCP_SERVICE_JSON_PATH` and `GCP_PROJECT_ID`
-  - To use [HMAC authentication](https://cloud.google.com/storage/docs/authentication/hmackeys), set `GCP_ACCESS_KEY_ID`, `GCP_SECRET_ACCESS_KEY`, and `GCP_PROJECT_ID`
+- For GCS(*)
+  - Set `GCP_SERVICE_JSON_PATH`, or `GCP_CLIENT_EMAIL` and `GCP_PRIVATE_KEY`.  
+    For detail, see [service account authentication](https://cloud.google.com/docs/authentication/production).
+
+(*) You can't use HMAC authentication to authenticate GCS. (https://github.com/googleapis/nodejs-storage/issues/117)
 
 # Migrate from [weseek/mongodb-awesome-backup](https://github.com/weseek/mongodb-awesome-backup)
 
@@ -45,8 +47,6 @@ Change the following environment variables.
 | weseek/mongodb-awesome-backup | mongodb-restore |
 | ----------------------------- | -------------- |
 | `AWSCLI_ENDPOINT_OPT` | `AWS_ENDPOINT_URL` |
-| `GCP_ACCESS_KEY_ID` | `GCP_CLIENT_EMAIL` |
-| `GCP_SECRET_ACCESS_KEY` | `GCP_PRIVATE_KEY` |
 | `MONGODB_URI` | `RESTORE_TOOL_OPTIONS` |
 | `MONGODB_HOST` | `RESTORE_TOOL_OPTIONS` |
 | `MONGODB_DBNAME` | `RESTORE_TOOL_OPTIONS` |
@@ -55,6 +55,13 @@ Change the following environment variables.
 | `MONGODB_AUTHDB` | `RESTORE_TOOL_OPTIONS` |
 | `AWSCLIOPT` | - **DISABLED** |
 | `GCSCLIOPT` | - **DISABLED** |
+
+### Use service account authentication
+
+You can't use HMAC authentication to authenticate GCS. (https://github.com/googleapis/nodejs-storage/issues/117)
+
+So, you need to use [service account authentication](https://cloud.google.com/docs/authentication/production).
+Set `GCP_SERVICE_JSON_PATH`, or `GCP_CLIENT_EMAIL` and `GCP_PRIVATE_KEY`.
 
 ### Set proper timezone
 

--- a/apps/postgresql-backup/README.md
+++ b/apps/postgresql-backup/README.md
@@ -41,6 +41,8 @@ S3 or GCS authentication is required depending on the storage service used.
 
 - For S3
   - Set `AWS_REGION` and `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
-- For GCS
-  - To use [service account authentication](https://cloud.google.com/docs/authentication/production), create JSON Web Key and set `GCP_SERVICE_JSON_PATH` and `GCP_PROJECT_ID`
-  - To use [HMAC authentication](https://cloud.google.com/storage/docs/authentication/hmackeys), set `GCP_ACCESS_KEY_ID`, `GCP_SECRET_ACCESS_KEY`, and `GCP_PROJECT_ID`
+- For GCS(*)
+  - Set `GCP_SERVICE_JSON_PATH`, or `GCP_CLIENT_EMAIL` and `GCP_PRIVATE_KEY`.  
+    For detail, see [service account authentication](https://cloud.google.com/docs/authentication/production).
+
+(*) You can't use HMAC authentication to authenticate GCS. (https://github.com/googleapis/nodejs-storage/issues/117)

--- a/apps/postgresql-restore/README.md
+++ b/apps/postgresql-restore/README.md
@@ -37,6 +37,8 @@ S3 or GCS authentication is required depending on the storage service used.
 
 - For S3
   - Set `AWS_REGION` and `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
-- For GCS
-  - To use [service account authentication](https://cloud.google.com/docs/authentication/production), create JSON Web Key and set `GCP_SERVICE_JSON_PATH` and `GCP_PROJECT_ID`
-  - To use [HMAC authentication](https://cloud.google.com/storage/docs/authentication/hmackeys), set `GCP_ACCESS_KEY_ID`, `GCP_SECRET_ACCESS_KEY`, and `GCP_PROJECT_ID`
+- For GCS(*)
+  - Set `GCP_SERVICE_JSON_PATH`, or `GCP_CLIENT_EMAIL` and `GCP_PRIVATE_KEY`.  
+    For detail, see [service account authentication](https://cloud.google.com/docs/authentication/production).
+
+(*) You can't use HMAC authentication to authenticate GCS. (https://github.com/googleapis/nodejs-storage/issues/117)

--- a/apps/prune/README.md
+++ b/apps/prune/README.md
@@ -34,6 +34,8 @@ S3 or GCS authentication is required depending on the storage service used.
 
 - For S3
   - Set `AWS_REGION` and `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
-- For GCS
-  - To use [service account authentication](https://cloud.google.com/docs/authentication/production), create JSON Web Key and set `GCP_SERVICE_JSON_PATH` and `GCP_PROJECT_ID`
-  - To use [HMAC authentication](https://cloud.google.com/storage/docs/authentication/hmackeys), set `GCP_ACCESS_KEY_ID`, `GCP_SECRET_ACCESS_KEY`, and `GCP_PROJECT_ID`
+- For GCS(*)
+  - Set `GCP_SERVICE_JSON_PATH`, or `GCP_CLIENT_EMAIL` and `GCP_PRIVATE_KEY`.  
+    For detail, see [service account authentication](https://cloud.google.com/docs/authentication/production).
+
+(*) You can't use HMAC authentication to authenticate GCS. (https://github.com/googleapis/nodejs-storage/issues/117)


### PR DESCRIPTION
The HMAC authentication could not be used for GCS authentication, although it was described in the documentation, so this has been corrected.