### PR TITLE
fix: (devcontainer) add "-y" when running "apt-get install"

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -74,6 +74,6 @@ RUN curl https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o /tmp/awscli
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" >> /etc/apt/sources.list.d/google-cloud-sdk.list \
       && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
       && apt-get update \
-      && apt-get install google-cloud-cli \
+      && apt-get install -y google-cloud-cli \
       && apt-get clean \
       && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Currently, building devcontainer will fail since "apt-get" prompts and aborts.
This PR fixes it.