### PR TITLE
support: Merge dependent libs automatically

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,36 +1,40 @@
 categories:
 - title: 'BREAKING CHANGES'
   labels:
-  - 'breaking'
+  - 'type/breaking'
 - title: '💎 Features'
   labels:
-  - 'feature'
+  - 'type/feature'
 - title: '🚀 Improvement'
   labels:
-  - 'improvement'
+  - 'type/improvement'
 - title: '🐛 Bug Fixes'
   labels:
-  - 'bug'
+  - 'type/bug'
 - title: '🧰 Maintenance'
   labels:
-  - 'support'
-  - 'dependencies'
+  - 'type/support'
+  - 'type/dependencies'
 category-template: '### $TITLE'
 change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 autolabeler:
-- label: 'feature'
+- label: 'type/feature'
   branch:
   - '/^feat\/.+/'
-- label: 'improvement'
+  title:
+  - '/^feat/i'
+- label: 'type/improvement'
   branch:
   - '/^imprv\/.+/'
-- label: 'bug'
+  title:
+  - '/^imprv/i'
+- label: 'type/bug'
   branch:
   - '/^fix\/.+/'
   title:
   - '/^fix/i'
-- label: 'support'
+- label: 'type/support'
   branch:
   - '/^support\/.+/'
   title:
@@ -40,13 +44,13 @@ autolabeler:
   - '/^docs/i'
   - '/^test/i'
 include-labels:
-- breaking
-- feature
-- improvement
-- bug
-- support
-- dependencies
+- type/breaking
+- type/feature
+- type/improvement
+- type/bug
+- type/support
+- type/dependencies
 exclude-labels:
-- 'exclude from changelog'
+- 'flag/exclude-from-changelog'
 template: |
   $CHANGES

--- a/.github/workflows/misc-pr_to_master.yaml
+++ b/.github/workflows/misc-pr_to_master.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     if: >
-      !contains( github.event.pull_request.labels.*.name, 'exclude from changelog' )
+      !contains( github.event.pull_request.labels.*.name, 'flag/exclude-from-changelog' )
 
     steps:
     - uses: release-drafter/release-drafter@v5
@@ -31,7 +31,7 @@ jobs:
     # - Created by "dependabot", "github-actions"
     if: >
       (
-        !contains( github.event.pull_request.labels.*.name, 'exclude from changelog' )
+        !contains( github.event.pull_request.labels.*.name, 'flag/exclude-from-changelog' )
         && !startsWith( github.head_ref, 'dependabot/' )
         && !contains( github.actor, 'github-actions' )
       )

--- a/.github/workflows/release-prepare_next_master.yaml
+++ b/.github/workflows/release-prepare_next_master.yaml
@@ -23,7 +23,7 @@ jobs:
     - run: yarn install
     - name: Bump up version
       run: |
-        git config user.name github-actions
+        git config user.name github-actions[bot]
         git config user.email github-actions@github.com
         git checkout -b next-version origin/master
 
@@ -32,6 +32,6 @@ jobs:
         git commit -am 'Bump up version'
         git push origin next-version
 
-        gh pr create --title 'Bump up patch version' --body '' --label 'exclude from changelog'
+        gh pr create --title 'Bump up patch version' --body '' --label 'flag/exclude-from-changelog,type/prepare-next-version'
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.mergify
+++ b/.mergify
@@ -1,0 +1,41 @@
+shared:
+  required_actions_were_succeeded_or_skipped: &required_actions_were_succeeded_or_skipped
+    - or:
+        - check-success = test
+        - check-skipped = test
+    - or:
+        - check-skipped = test (mariadb)
+        - check-success = test (mariadb)
+    - or:
+        - check-skipped = test (mongodb)
+        - check-success = test (mongodb)
+    - or:
+        - check-skipped = test (postgresql)
+        - check-success = test (postgresql)
+
+pull_request_rules:
+  - name: All required actions were succeeded or skipped
+    conditions:
+      - and: *required_actions_were_succeeded_or_skipped
+    actions:
+      post_check:
+        title: required-actions-were-succeeded-or-skipped
+        success_conditions:
+          - and: *required_actions_were_succeeded_or_skipped
+  - name: Automatic merge for Preparing next version
+    conditions:
+      - author = github-actions[bot]
+      - label = "type/prepare-next-version"
+    actions:
+      review:
+        type: APPROVE
+        message: Automatically approving github-actions[bot]
+      merge:
+        method: merge
+  - name: Automatic merge for Dependabot pull requests
+    conditions:
+    - author = dependabot[bot]
+    - and: *required_actions_were_succeeded_or_skipped
+    actions:
+      merge:
+        method: merge


### PR DESCRIPTION
This PR will allow PRs created by dependabot to be merged if these pass the test.

In addition, it will allow repository to change the configuration so that PRs can be merged if the test passes, including if the test is skipped.
