### PR TITLE
imprv: Configurable DB tool's version

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.217.2/containers/typescript-node/.devcontainer/base.Dockerfile
 
-# You should set same Node.js version and Linux distribution as docker/Dockerfile
+# You must set same Node.js version and Linux distribution as docker/Dockerfile
 # [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
 ARG VARIANT="16"
 FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -31,8 +31,8 @@ RUN chown -R $USER_UID:$USER_GID /home/$USERNAME /awesome-database-backup;
 
 # Install tools
 ARG MongoToolVersion=100.5.2
-ARG PostgreSQLVersion=11
-ARG MariaDBVersion=10.5.28
+ARG PostgreSQLClientVersion=11
+ARG MariaDBClientVersion=10.5.28
 ## bzip2, curl command
 RUN apt-get update \
       && apt-get install -y bzip2 curl \
@@ -57,11 +57,11 @@ RUN echo "deb http://apt.postgresql.org/pub/repos/apt $(cat /etc/os-release | gr
       && apt-get install -y curl ca-certificates gnupg \
       && curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
       && apt-get update \
-      && apt-get install -y postgresql-common postgresql-client-${PostgreSQLVersion} --no-install-recommends \
+      && apt-get install -y postgresql-common postgresql-client-${PostgreSQLClientVersion} --no-install-recommends \
       && apt-get clean \
       && rm -rf /var/lib/apt/lists/*
 ## MariaDB tools
-RUN curl -sSL https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | bash -s -- --mariadb-server-version=${MariaDBVersion} \
+RUN curl -sSL https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | bash -s -- --mariadb-server-version=${MariaDBClientVersion} \
       && apt-get update \
       && apt-get install -y mariadb-common mariadb-client --no-install-recommends \
       && apt-get clean \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,6 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.217.2/containers/typescript-node/.devcontainer/base.Dockerfile
 
+# You should set same Node.js version and Linux distribution as docker/Dockerfile
 # [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
 ARG VARIANT="16"
 FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}
@@ -29,6 +30,9 @@ RUN if [ "$USER_GID" != "1000" ] || [ "$USER_UID" != "1000" ]; then \
 RUN chown -R $USER_UID:$USER_GID /home/$USERNAME /awesome-database-backup;
 
 # Install tools
+ARG MongoToolVersion=100.5.2
+ARG PostgreSQLVersion=11
+ARG MariaDBVersion=10.5.28
 ## bzip2, curl command
 RUN apt-get update \
       && apt-get install -y bzip2 curl \
@@ -43,21 +47,22 @@ RUN apt-get update \
       && rm ./mongodb-mongosh.deb
 ## mongo tools
 RUN apt-get update \
-      && curl https://fastdl.mongodb.org/tools/db/mongodb-database-tools-debian10-x86_64-100.5.2.deb -o mongodb-database-tools.deb \
+      && curl https://fastdl.mongodb.org/tools/db/mongodb-database-tools-debian10-x86_64-${MongoToolVersion}.deb -o mongodb-database-tools.deb \
       && apt-get install -y ./mongodb-database-tools.deb \
       && apt-get clean \
       && rm -rf /var/lib/apt/lists/* \
       && rm ./mongodb-database-tools.deb
 ## PostgreSQL tools
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt $(cat /etc/os-release | grep VERSION_CODENAME | cut -d = -f 2)-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
       && apt-get install -y curl ca-certificates gnupg \
       && curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
       && apt-get update \
-      && apt-get install -y postgresql-common postgresql-client-14 --no-install-recommends \
+      && apt-get install -y postgresql-common postgresql-client-${PostgreSQLVersion} --no-install-recommends \
       && apt-get clean \
       && rm -rf /var/lib/apt/lists/*
 ## MariaDB tools
-RUN apt-get update \
+RUN curl -sSL https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | bash -s -- --mariadb-server-version=${MariaDBVersion} \
+      && apt-get update \
       && apt-get install -y mariadb-common mariadb-client --no-install-recommends \
       && apt-get clean \
       && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -54,7 +54,6 @@ RUN apt-get update \
       && rm ./mongodb-database-tools.deb
 ## PostgreSQL tools
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt $(cat /etc/os-release | grep VERSION_CODENAME | cut -d = -f 2)-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
-      && apt-get install -y curl ca-certificates gnupg \
       && curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
       && apt-get update \
       && apt-get install -y postgresql-common postgresql-client-${PostgreSQLClientVersion} --no-install-recommends \

--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -18,8 +18,8 @@ services:
     working_dir: /awesome-database-backup
 
   mongo:
-    # You must set newest version of .github/workflows/container-publish.yaml
-    # ex. Set "100.5.3" if the following
+    # You must set compatible version with newest version of mongotool in .github/workflows/container-publish.yaml
+    # ex. Set "6" if the following
     # - db_type: mongodb
     #   db_tool_version: 100.5.2
     # - db_type: mongodb

--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -18,7 +18,13 @@ services:
     working_dir: /awesome-database-backup
 
   mongo:
-    image: mongo:5.0.6
+    # You must set newest version of .github/workflows/container-publish.yaml
+    # ex. Set "100.5.3" if the following
+    # - db_type: mongodb
+    #   db_tool_version: 100.5.2
+    # - db_type: mongodb
+    #   db_tool_version: 100.5.3
+    image: mongo:6
     environment:
       MONGO_INITDB_ROOT_USERNAME: ${DB_ADMIN_USERNAME:-root}
       MONGO_INITDB_ROOT_PASSWORD: ${DB_ADMIN_PASSWORD:-password}
@@ -37,7 +43,13 @@ services:
       retries: 5
 
   postgres:
-    image: postgres:14.2
+    # You must set newest version of .github/workflows/container-publish.yaml
+    # ex. Set "12" if the following
+    # - db_type: postgresql
+    #   db_tool_version: 11
+    # - db_type: postgresql
+    #   db_tool_version: 12
+    image: postgres:11-bullseye
     environment:
       POSTGRES_DB: ${DB_NAME:-test}
       POSTGRES_PASSWORD: ${DB_ADMIN_PASSWORD:-password}
@@ -50,7 +62,13 @@ services:
       retries: 5
 
   mariadb:
-    image: mariadb:10.8.2
+    # You must set newest version of .github/workflows/container-publish.yaml
+    # ex. Set "10.6.21" if the following
+    # - db_type: mariadb
+    #   db_tool_version: 10.5.28
+    # - db_type: mariadb
+    #   db_tool_version: 10.6.21
+    image: mariadb:10.5.28
     environment:
       MARIADB_USER: ${DB_ADMIN_USERNAME:-root}
       MARIADB_ROOT_PASSWORD: ${DB_ADMIN_PASSWORD:-password}

--- a/.github/workflows/container-publish.yaml
+++ b/.github/workflows/container-publish.yaml
@@ -22,6 +22,7 @@ jobs:
         - dbType: postgresql
           dbToolVersion: 11
           dockerTagSuffix: postgresql-11
+        # Valid versions can be found here https://dlm.mariadb.com/rest/releases/mariadb_server/
         - dbType: mariadb
           dbToolVersion: 10.5.28
           dockerTagSuffix: mariadb-10.5.28

--- a/.github/workflows/container-publish.yaml
+++ b/.github/workflows/container-publish.yaml
@@ -17,13 +17,13 @@ jobs:
         - file
         include:
         - dbType: mongodb
-          dbVersion: 100.5.2
+          dbToolVersion: 100.5.2
           dockerTagSuffix: mongotool-100.5.2
         - dbType: postgresql
-          dbVersion: 11
+          dbToolVersion: 11
           dockerTagSuffix: postgresql-11
         - dbType: mariadb
-          dbVersion: 10.5.28
+          dbToolVersion: 10.5.28
           dockerTagSuffix: mariadb-10.5.28
       fail-fast: false
 

--- a/.github/workflows/container-publish.yaml
+++ b/.github/workflows/container-publish.yaml
@@ -15,6 +15,16 @@ jobs:
         - postgresql
         - mariadb
         - file
+        include:
+        - dbType: mongodb
+          dbVersion: 100.5.2
+          dockerTagSuffix: mongotool-100.5.2
+        - dbType: postgresql
+          dbVersion: 11
+          dockerTagSuffix: postgresql-11
+        - dbType: mariadb
+          dbVersion: 10.5.28
+          dockerTagSuffix: mariadb-10.5.28
       fail-fast: false
 
     steps:
@@ -44,6 +54,7 @@ jobs:
           type=semver,value=v${{ steps.package-json.outputs.packageVersion }},pattern={{major}}
           type=semver,value=v${{ steps.package-json.outputs.packageVersion }},pattern={{major}}.{{minor}}
           type=semver,value=v${{ steps.package-json.outputs.packageVersion }},pattern={{major}}.{{minor}}.{{patch}}
+          type=semver,value=v${{ steps.package-json.outputs.packageVersion }}-${{ matrix.dockerTagSuffix }},pattern={{major}}.{{minor}}.{{patch}}
     - name: Build and push container
       uses: docker/build-push-action@v5
       with:
@@ -55,6 +66,7 @@ jobs:
           packageScope=${{ steps.pkg_meta.outputs.package_scope }}
           packagePath=${{ steps.pkg_meta.outputs.package_path }}
           dbType=${{ matrix.db_type }}
+          dbVersion=${{ matrix.db_version }}
         tags: ${{ steps.meta.outputs.tags }}
 
     - name: Update Docker hub's description

--- a/.github/workflows/container-publish.yaml
+++ b/.github/workflows/container-publish.yaml
@@ -16,16 +16,16 @@ jobs:
         - mariadb
         - file
         include:
-        - dbType: mongodb
-          dbToolVersion: 100.5.2
-          dockerTagSuffix: mongotool-100.5.2
-        - dbType: postgresql
-          dbToolVersion: 11
-          dockerTagSuffix: postgresql-11
+        - db_type: mongodb
+          db_tool_version: 100.5.2
+          docker_tag_suffix: mongotool-100.5.2
+        - db_type: postgresql
+          db_tool_version: 11
+          docker_tag_suffix: postgresql-11
         # Valid versions can be found here https://dlm.mariadb.com/rest/releases/mariadb_server/
-        - dbType: mariadb
-          dbToolVersion: 10.5.28
-          dockerTagSuffix: mariadb-10.5.28
+        - db_type: mariadb
+          db_tool_version: 10.5.28
+          docker_tag_suffix: mariadb-10.5.28
       fail-fast: false
 
     steps:
@@ -55,7 +55,7 @@ jobs:
           type=semver,value=v${{ steps.package-json.outputs.packageVersion }},pattern={{major}}
           type=semver,value=v${{ steps.package-json.outputs.packageVersion }},pattern={{major}}.{{minor}}
           type=semver,value=v${{ steps.package-json.outputs.packageVersion }},pattern={{major}}.{{minor}}.{{patch}}
-          type=semver,value=v${{ steps.package-json.outputs.packageVersion }}-${{ matrix.dockerTagSuffix }},pattern={{major}}.{{minor}}.{{patch}}
+          type=semver,value=v${{ steps.package-json.outputs.packageVersion }}-${{ matrix.docker_tag_suffix }},pattern={{major}}.{{minor}}.{{patch}}
     - name: Build and push container
       uses: docker/build-push-action@v5
       with:
@@ -67,7 +67,7 @@ jobs:
           packageScope=${{ steps.pkg_meta.outputs.package_scope }}
           packagePath=${{ steps.pkg_meta.outputs.package_path }}
           dbType=${{ matrix.db_type }}
-          dbVersion=${{ matrix.db_version }}
+          dbToolVersion=${{ matrix.db_tool_version }}
         tags: ${{ steps.meta.outputs.tags }}
 
     - name: Update Docker hub's description

--- a/.github/workflows/container-publish.yaml
+++ b/.github/workflows/container-publish.yaml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      # Set same as container-publish.yaml
       matrix:
         db_type:
         - mongodb
@@ -16,9 +17,11 @@ jobs:
         - mariadb
         - file
         include:
+        # Valid versions can be found here https://www.mongodb.com/try/download/database-tools/releases/archive
         - db_type: mongodb
           db_tool_version: 100.5.2
           docker_tag_suffix: mongotool-100.5.2
+        # Valid versions can be found here https://apt.postgresql.org/pub/repos/apt/dists/bullseye-pgdg/
         - db_type: postgresql
           db_tool_version: 11
           docker_tag_suffix: postgresql-11

--- a/.github/workflows/container-publish.yaml
+++ b/.github/workflows/container-publish.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      # Set same as container-publish.yaml
+      # Set same as container-test.yaml
       matrix:
         db_type:
         - mongodb

--- a/.github/workflows/container-test.yaml
+++ b/.github/workflows/container-test.yaml
@@ -18,6 +18,14 @@ jobs:
         - postgresql
         - mariadb
         - file
+        include:
+        - db_type: mongodb
+          db_tool_version: 100.5.2
+        - db_type: postgresql
+          db_tool_version: 11
+        # Valid versions can be found here https://dlm.mariadb.com/rest/releases/mariadb_server/
+        - db_type: mariadb
+          db_tool_version: 10.5.28
 
     steps:
     - uses: actions/checkout@v4
@@ -49,6 +57,7 @@ jobs:
           packageScope=${{ steps.pkg_meta.outputs.package_scope }}
           packagePath=${{ steps.pkg_meta.outputs.package_path }}
           dbType=${{ matrix.db_type }}
+          dbToolVersion=${{ matrix.db_tool_version }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
         tags: ${{ steps.pkg_meta.outputs.package_image_name }}:latest

--- a/.github/workflows/container-test.yaml
+++ b/.github/workflows/container-test.yaml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      # Set same as container-test.yaml
       matrix:
         db_type:
         - mongodb
@@ -19,8 +20,10 @@ jobs:
         - mariadb
         - file
         include:
+        # Valid versions can be found here https://www.mongodb.com/try/download/database-tools/releases/archive
         - db_type: mongodb
           db_tool_version: 100.5.2
+        # Valid versions can be found here https://apt.postgresql.org/pub/repos/apt/dists/bullseye-pgdg/
         - db_type: postgresql
           db_tool_version: 11
         # Valid versions can be found here https://dlm.mariadb.com/rest/releases/mariadb_server/

--- a/.github/workflows/container-test.yaml
+++ b/.github/workflows/container-test.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      # Set same as container-test.yaml
+      # Set same as container-publish.yaml
       matrix:
         db_type:
         - mongodb

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -65,7 +65,8 @@ RUN apt-get update \
 
 FROM tool-common AS mongodb-tools
 
-ARG dbToolVersion=100.5.2
+# YOU MUST SET dbToolVersion
+ARG dbToolVersion
 RUN apt-get update \
       && curl https://fastdl.mongodb.org/tools/db/mongodb-database-tools-debian10-x86_64-${dbToolVersion}.deb -o mongodb-database-tools.deb \
       && apt-get install -y ./mongodb-database-tools.deb \
@@ -75,7 +76,8 @@ RUN apt-get update \
 
 FROM tool-common AS postgresql-tools
 
-ARG dbToolVersion=11
+# YOU MUST SET dbToolVersion
+ARG dbToolVersion
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt $(cat /etc/os-release | grep VERSION_CODENAME | cut -d = -f 2)-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
       && apt-get install -y curl ca-certificates gnupg \
       && curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
@@ -86,8 +88,8 @@ RUN echo "deb http://apt.postgresql.org/pub/repos/apt $(cat /etc/os-release | gr
 
 FROM tool-common AS mariadb-tools
 
-# Valid versions can be found here https://dlm.mariadb.com/rest/releases/mariadb_server/
-ARG dbToolVersion=10.5.28
+# YOU MUST SET dbToolVersion
+ARG dbToolVersion
 RUN curl -sSL https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | bash -s -- --mariadb-server-version=${dbToolVersion} \
       && apt-get update \
       && apt-get install -y mariadb-common mariadb-client --no-install-recommends \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,6 @@
 ARG dbType
 
 # You should set same Node.js version and Linux distribution as .devcontainer/Dockerfile
-# FROM node:16.14.2-bullseye-slim AS base
 FROM node:16.14.2-bullseye-slim AS base
 
 ##
@@ -66,7 +65,7 @@ RUN apt-get update \
 
 FROM tool-common AS mongodb-tools
 
-ARG dbVersion=100.5.2
+ARG dbToolVersion=100.5.2
 RUN apt-get update \
       && curl https://fastdl.mongodb.org/tools/db/mongodb-database-tools-debian10-x86_64-${dbVersion}.deb -o mongodb-database-tools.deb \
       && apt-get install -y ./mongodb-database-tools.deb \
@@ -76,7 +75,7 @@ RUN apt-get update \
 
 FROM tool-common AS postgresql-tools
 
-ARG dbVersion=11
+ARG dbToolVersion=11
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt $(cat /etc/os-release | grep VERSION_CODENAME | cut -d = -f 2)-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
       && apt-get install -y curl ca-certificates gnupg \
       && curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
@@ -88,7 +87,7 @@ RUN echo "deb http://apt.postgresql.org/pub/repos/apt $(cat /etc/os-release | gr
 FROM tool-common AS mariadb-tools
 
 # Valid versions can be found here https://dlm.mariadb.com/rest/releases/mariadb_server/
-ARG dbVersion=10.5.28
+ARG dbToolVersion=10.5.28
 RUN curl -sSL https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | bash -s -- --mariadb-server-version=${dbVersion} \
       && apt-get update \
       && apt-get install -y mariadb-common mariadb-client --no-install-recommends \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,8 @@
 ARG dbType
 
-FROM node:16.14.2-slim AS base
+# You should set same Node.js version and Linux distribution as .devcontainer/Dockerfile
+# FROM node:16.14.2-bullseye-slim AS base
+FROM node:16.14.2-bullseye-slim AS base
 
 ##
 ## Prepare a subset of this monorepo
@@ -64,8 +66,9 @@ RUN apt-get update \
 
 FROM tool-common AS mongodb-tools
 
+ARG dbVersion=100.5.2
 RUN apt-get update \
-      && curl https://fastdl.mongodb.org/tools/db/mongodb-database-tools-debian10-x86_64-100.5.2.deb -o mongodb-database-tools.deb \
+      && curl https://fastdl.mongodb.org/tools/db/mongodb-database-tools-debian10-x86_64-${dbVersion}.deb -o mongodb-database-tools.deb \
       && apt-get install -y ./mongodb-database-tools.deb \
       && apt-get clean \
       && rm -rf /var/lib/apt/lists/* \
@@ -73,14 +76,21 @@ RUN apt-get update \
 
 FROM tool-common AS postgresql-tools
 
-RUN apt-get update \
-      && apt-get install -y postgresql-common postgresql-client --no-install-recommends \
+ARG dbVersion=11
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt $(cat /etc/os-release | grep VERSION_CODENAME | cut -d = -f 2)-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
+      && apt-get install -y curl ca-certificates gnupg \
+      && curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
+      && apt-get update \
+      && apt-get install -y postgresql-common postgresql-client-${dbVersion} --no-install-recommends \
       && apt-get clean \
       && rm -rf /var/lib/apt/lists/*
 
 FROM tool-common AS mariadb-tools
 
-RUN apt-get update \
+# Valid versions can be found here https://dlm.mariadb.com/rest/releases/mariadb_server/
+ARG dbVersion=10.5.28
+RUN curl -sSL https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | bash -s -- --mariadb-server-version=${dbVersion} \
+      && apt-get update \
       && apt-get install -y mariadb-common mariadb-client --no-install-recommends \
       && apt-get clean \
       && rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -67,7 +67,7 @@ FROM tool-common AS mongodb-tools
 
 ARG dbToolVersion=100.5.2
 RUN apt-get update \
-      && curl https://fastdl.mongodb.org/tools/db/mongodb-database-tools-debian10-x86_64-${dbVersion}.deb -o mongodb-database-tools.deb \
+      && curl https://fastdl.mongodb.org/tools/db/mongodb-database-tools-debian10-x86_64-${dbToolVersion}.deb -o mongodb-database-tools.deb \
       && apt-get install -y ./mongodb-database-tools.deb \
       && apt-get clean \
       && rm -rf /var/lib/apt/lists/* \
@@ -80,7 +80,7 @@ RUN echo "deb http://apt.postgresql.org/pub/repos/apt $(cat /etc/os-release | gr
       && apt-get install -y curl ca-certificates gnupg \
       && curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
       && apt-get update \
-      && apt-get install -y postgresql-common postgresql-client-${dbVersion} --no-install-recommends \
+      && apt-get install -y postgresql-common postgresql-client-${dbToolVersion} --no-install-recommends \
       && apt-get clean \
       && rm -rf /var/lib/apt/lists/*
 
@@ -88,7 +88,7 @@ FROM tool-common AS mariadb-tools
 
 # Valid versions can be found here https://dlm.mariadb.com/rest/releases/mariadb_server/
 ARG dbToolVersion=10.5.28
-RUN curl -sSL https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | bash -s -- --mariadb-server-version=${dbVersion} \
+RUN curl -sSL https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | bash -s -- --mariadb-server-version=${dbToolVersion} \
       && apt-get update \
       && apt-get install -y mariadb-common mariadb-client --no-install-recommends \
       && apt-get clean \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -59,7 +59,7 @@ RUN yarn run turbo run build --scope="${packageScope}" --include-dependencies --
 FROM base AS tool-common
 
 RUN apt-get update \
-      && apt-get install -y bzip2 curl \
+      && apt-get install -y bzip2 curl ca-certificates gnupg \
       && apt-get clean \
       && rm -rf /var/lib/apt/lists/*
 
@@ -79,7 +79,6 @@ FROM tool-common AS postgresql-tools
 # YOU MUST SET dbToolVersion
 ARG dbToolVersion
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt $(cat /etc/os-release | grep VERSION_CODENAME | cut -d = -f 2)-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
-      && apt-get install -y curl ca-certificates gnupg \
       && curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
       && apt-get update \
       && apt-get install -y postgresql-common postgresql-client-${dbToolVersion} --no-install-recommends \


### PR DESCRIPTION
* Configurable DB tool's version
* Adjust DB tool's version in development, test, production environment
    * mongotool: 100.5.2
    * postgresql: 11
    * mariadb: 10.5.28
* Add DB tool's version to docker image tag (ex. `weseek/awesome-mariadb-backup:0.2.5-mariadb-10.5.28`)
