### PR TITLE
support: Update mariadb

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -32,7 +32,7 @@ RUN chown -R $USER_UID:$USER_GID /home/$USERNAME /awesome-database-backup;
 # Install tools
 ARG MongoToolVersion=100.5.2
 ARG PostgreSQLClientVersion=11
-ARG MariaDBClientVersion=10.11.11
+ARG MariaDBClientVersion=11.7.2
 ## bzip2, curl command
 RUN apt-get update \
       && apt-get install -y bzip2 curl \

--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -68,7 +68,7 @@ services:
     #   db_tool_version: 10.5.28
     # - db_type: mariadb
     #   db_tool_version: 10.6.21
-    image: mariadb:10.5.28
+    image: mariadb:11.7.2
     environment:
       MARIADB_USER: ${DB_ADMIN_USERNAME:-root}
       MARIADB_ROOT_PASSWORD: ${DB_ADMIN_PASSWORD:-password}

--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -77,7 +77,7 @@ services:
     healthcheck:
       test:
       - CMD
-      - mysqladmin
+      - mariadb-admin
       - ping
       - -h
       - localhost

--- a/.github/workflows/container-publish.yaml
+++ b/.github/workflows/container-publish.yaml
@@ -49,9 +49,11 @@ jobs:
         # awesome-mariadb-backup
         # Valid versions can be found here https://dlm.mariadb.com/rest/releases/mariadb_server/
         - db_type: mariadb
-          version: 10.6.21
+          version: 11.4.5
         - db_type: mariadb
-          version: 10.11.11
+          version: 11.7.2
+        - db_type: mariadb
+          version: 11.8.1
           isLatest: true
         # awesome-file-backup
         - db_type: file

--- a/.github/workflows/container-test.yaml
+++ b/.github/workflows/container-test.yaml
@@ -50,9 +50,11 @@ jobs:
         # awesome-mariadb-backup
         # Valid versions can be found here https://dlm.mariadb.com/rest/releases/mariadb_server/
         - db_type: mariadb
-          version: 10.6.21
+          version: 11.4.5
         - db_type: mariadb
-          version: 10.11.11
+          version: 11.7.2
+        - db_type: mariadb
+          version: 11.8.1
         # awesome-file-backup
         - db_type: file
 

--- a/apps/mariadb-backup/src/backup.ts
+++ b/apps/mariadb-backup/src/backup.ts
@@ -31,7 +31,7 @@ class MariaDBBackupCommand extends BackupCommand {
     logger.info(`backup ${dbDumpFilePath}...`);
     logger.info('dump MariaDB...');
     const { stdout, stderr } = await exec(
-      `set -o pipefail; mysqldump ${options.backupToolOptions} | bzip2 > ${dbDumpFilePath}`,
+      `set -o pipefail; mariadb-dump ${options.backupToolOptions} | bzip2 > ${dbDumpFilePath}`,
       { shell: '/bin/bash' },
     );
     return { stdout, stderr, dbDumpFilePath };

--- a/apps/mariadb-restore/src/restore.ts
+++ b/apps/mariadb-restore/src/restore.ts
@@ -18,7 +18,7 @@ class MariaDBSQLRestoreCommand extends RestoreCommand {
   async restoreDB(sourcePath: string, userSpecifiedOption?: string): Promise<{ stdout: string, stderr: string }> {
     logger.info('restore MariaDB...');
     return exec(
-      `set -o pipefail; cat ${sourcePath} | mysql ${userSpecifiedOption}`,
+      `set -o pipefail; cat ${sourcePath} | mariadb ${userSpecifiedOption}`,
       { shell: '/bin/bash' },
     );
   }

--- a/docker/test/mariadb/structure-tests.yml
+++ b/docker/test/mariadb/structure-tests.yml
@@ -36,13 +36,13 @@ commandTests:
   command: which
   args: ["bzip2"]
 
-- name: expect "which mysqldump" return valid path
+- name: expect "which mariadb-dump" return valid path
   command: which
-  args: ["mysqldump"]
+  args: ["mariadb-dump"]
 
-- name: expect "which mysql" return valid path
+- name: expect "which mariadb" return valid path
   command: which
-  args: ["mysql"]
+  args: ["mariadb"]
 
 # ================================================================================
 # Execution
@@ -86,17 +86,17 @@ commandTests:
 # ----------
 # backup tool versions
 # ----------
-# `mysqldump --version` returns ex. "mysqldump  Ver 10.19 Distrib 10.5.28-MariaDB, for debian-linux-gnu (x86_64)"
-- name: expect "mysqldump --version" includes "${BACKUP_TOOL_VERSION}-MariaDB"
+# `mariadb-dump --version` returns ex. "mariadb-dump  Ver 10.19 Distrib 10.5.28-MariaDB, for debian-linux-gnu (x86_64)"
+- name: expect "mariadb-dump --version" includes "${BACKUP_TOOL_VERSION}-MariaDB"
   command: sh
   args:
   - -c
-  - mysqldump --version | grep -- "${BACKUP_TOOL_VERSION}-MariaDB"
+  - mariadb-dump --version | grep -- "${BACKUP_TOOL_VERSION}-MariaDB"
   exitCode: 0
-# `mysql --version` returns ex. "mysql  Ver 15.1 Distrib 10.5.28-MariaDB, for debian-linux-gnu (x86_64) using  EditLine wrapper"
-- name: expect "mysql --version" includes "${BACKUP_TOOL_VERSION}-MariaDB"
+# `mariadb --version` returns ex. "mariadb  Ver 15.1 Distrib 10.5.28-MariaDB, for debian-linux-gnu (x86_64) using  EditLine wrapper"
+- name: expect "mariadb --version" includes "${BACKUP_TOOL_VERSION}-MariaDB"
   command: sh
   args:
   - -c
-  - mysql --version | grep -- "${BACKUP_TOOL_VERSION}-MariaDB"
+  - mariadb --version | grep -- "${BACKUP_TOOL_VERSION}-MariaDB"
   exitCode: 0


### PR DESCRIPTION
* Update MariaDB to v11
    * Use newer commands instead of legacy commands (see. https://mariadb.com/kb/en/legacy-clients-and-utilities/)
        * `mysql` -> `mariadb`
        * `mysqldump` -> `mariadb-dump`
