### PR TITLE
imprv: Tuning performance of uploading to S3 and GCS

### DIFF
--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -9,6 +9,8 @@ services:
     tty: true
     environment:
       TZ: Asia/Tokyo
+      GCP_ENDPOINT_URL: http://fake-gcs-server:4443
+      AWS_ENDPOINT_URL: http://minio:9000
     networks:
       default:
       test:

--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -10,7 +10,7 @@ services:
     environment:
       TZ: Asia/Tokyo
       GCP_ENDPOINT_URL: http://fake-gcs-server:4443
-      AWS_ENDPOINT_URL: http://minio:9000
+      AWS_ENDPOINT_URL: http://s3.minio:9000
     networks:
       default:
       test:

--- a/.github/workflows/app-benchmark.yaml
+++ b/.github/workflows/app-benchmark.yaml
@@ -73,6 +73,7 @@ jobs:
     # Need to match the requirements of workflow-telemetry-action
     runs-on: ubuntu-22.04
     strategy:
+      max-parallel: 1
       matrix:
         run-script-name:
         - test:performance:tempfile_mode:s3

--- a/packages/storage-service-clients/src/config/logger/config.dev.ts
+++ b/packages/storage-service-clients/src/config/logger/config.dev.ts
@@ -1,0 +1,11 @@
+import { UniversalBunyanConfig } from 'universal-bunyan';
+
+const config: UniversalBunyanConfig = {
+  default: 'debug',
+
+  /*
+   * configure level for server
+   */
+};
+
+export default config;

--- a/packages/storage-service-clients/src/config/logger/config.prod.ts
+++ b/packages/storage-service-clients/src/config/logger/config.prod.ts
@@ -1,0 +1,11 @@
+import { UniversalBunyanConfig } from 'universal-bunyan';
+
+const config: UniversalBunyanConfig = {
+  default: 'info',
+
+  /*
+   * configure level for server
+   */
+};
+
+export default config;

--- a/packages/storage-service-clients/src/gcs.ts
+++ b/packages/storage-service-clients/src/gcs.ts
@@ -9,6 +9,9 @@ import {
   GCSURI,
   GCSStorageServiceClientConfig,
 } from './interfaces';
+import loggerFactory from './logger/factory';
+
+const logger = loggerFactory('storage-service-clients');
 
 /**
  * Client to manipulate GCS buckets
@@ -182,7 +185,9 @@ export class GCSStorageServiceClient implements IStorageServiceClient {
     const BLOCK_SIZE = 256 * 1024;
     const MIN_SIZE = 8 * 1024 * 1024;
 
-    return Math.max(Math.floor(totalHeapSize * 0.5 / BLOCK_SIZE) * BLOCK_SIZE, MIN_SIZE);
+    const calculatedChunkSize = totalHeapSize * 0.5 / BLOCK_SIZE;
+    logger.debug(`Calculated chunk size: ${calculatedChunkSize}`);
+    return Math.max(Math.floor(calculatedChunkSize) * BLOCK_SIZE, MIN_SIZE);
   }
 
 }

--- a/packages/storage-service-clients/src/gcs.ts
+++ b/packages/storage-service-clients/src/gcs.ts
@@ -178,14 +178,14 @@ export class GCSStorageServiceClient implements IStorageServiceClient {
   }
 
   private _chunkSizeCalculatedFromHeapSize() {
-    const { total_heap_size: totalHeapSize } = getHeapStatistics();
+    const { heap_size_limit: heapSizeLimit } = getHeapStatistics();
 
     // MUST BE A MULTIPLE OF 256 KiB, and 8MiB or more recommended
     // ref. https://cloud.google.com/storage/docs/performing-resumable-uploads?#chunked-upload
     const BLOCK_SIZE = 256 * 1024;
     const MIN_SIZE = 8 * 1024 * 1024;
 
-    const calculatedChunkSize = totalHeapSize * 0.5 / BLOCK_SIZE;
+    const calculatedChunkSize = heapSizeLimit * 0.5 / BLOCK_SIZE;
     logger.debug(`Calculated chunk size: ${calculatedChunkSize}`);
     return Math.max(Math.floor(calculatedChunkSize) * BLOCK_SIZE, MIN_SIZE);
   }

--- a/packages/storage-service-clients/src/gcs.ts
+++ b/packages/storage-service-clients/src/gcs.ts
@@ -178,14 +178,14 @@ export class GCSStorageServiceClient implements IStorageServiceClient {
   }
 
   private _chunkSizeCalculatedFromHeapSize() {
-    const { heap_size_limit: heapSizeLimit } = getHeapStatistics();
+    const { total_available_size: totalAvailableSize } = getHeapStatistics();
 
     // MUST BE A MULTIPLE OF 256 KiB, and 8MiB or more recommended
     // ref. https://cloud.google.com/storage/docs/performing-resumable-uploads?#chunked-upload
     const BLOCK_SIZE = 256 * 1024;
     const MIN_SIZE = 8 * 1024 * 1024;
 
-    const calculatedChunkSize = heapSizeLimit * 0.5 / BLOCK_SIZE;
+    const calculatedChunkSize = totalAvailableSize * 0.5 / BLOCK_SIZE;
     logger.debug(`Calculated chunk size: ${calculatedChunkSize}`);
     return Math.max(Math.floor(calculatedChunkSize) * BLOCK_SIZE, MIN_SIZE);
   }

--- a/packages/storage-service-clients/src/logger/factory.ts
+++ b/packages/storage-service-clients/src/logger/factory.ts
@@ -1,0 +1,17 @@
+import Logger from 'bunyan';
+import { createLogger } from 'universal-bunyan';
+
+import configForDev from '../config/logger/config.dev';
+import configForProd from '../config/logger/config.prod';
+
+const isProduction = process.env.NODE_ENV === 'production';
+const config = isProduction ? configForProd : configForDev;
+
+const loggerFactory = (name: string): Logger => {
+  return createLogger({
+    name,
+    config,
+  });
+};
+
+export default loggerFactory;

--- a/packages/storage-service-clients/src/s3.ts
+++ b/packages/storage-service-clients/src/s3.ts
@@ -221,12 +221,6 @@ export class S3StorageServiceClient implements IStorageServiceClient {
     const destinationS3Uri = this._parseFilePath(destinationUri);
     if (destinationS3Uri == null) throw new Error(`URI ${destinationUri} is not correct S3's`);
 
-    const highWaterMark = this._bufferSizeCalculatedFromHeapSize();
-    logger.debug(`Create PassThrough with highWaterMark: ${highWaterMark}(bytes)`);
-    const adjuster = new PassThrough({
-      highWaterMark,
-    });
-
     const queueSize = Math.min(
       this._queueSizeCalculatedFromCPU(),
       Math.floor(this._bufferSizeCalculatedFromHeapSize() / this._partSizeCalculatedFromHeapSize()),
@@ -240,7 +234,7 @@ export class S3StorageServiceClient implements IStorageServiceClient {
       params: {
         Bucket: destinationS3Uri.bucket,
         Key: path.join(destinationS3Uri.key, fileName),
-        Body: stream.pipe(adjuster),
+        Body: stream,
       },
     });
 

--- a/packages/storage-service-clients/src/s3.ts
+++ b/packages/storage-service-clients/src/s3.ts
@@ -13,7 +13,6 @@ import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { promises as StreamPromises, Readable } from 'stream';
 import { getHeapStatistics } from 'v8';
 import path from 'node:path';
-import { PassThrough } from 'node:stream';
 import {
   IStorageServiceClient,
   listS3FilesOptions,

--- a/packages/storage-service-clients/src/s3.ts
+++ b/packages/storage-service-clients/src/s3.ts
@@ -270,10 +270,10 @@ export class S3StorageServiceClient implements IStorageServiceClient {
   }
 
   private _bufferSizeCalculatedFromHeapSize() {
-    const { heap_size_limit: heapSizeLimit } = getHeapStatistics();
+    const { total_available_size: totalAvailableSize } = getHeapStatistics();
 
-    const calculatedSize = Math.floor(heapSizeLimit * 0.5);
-    logger.debug(`Calculated buffer size: ${calculatedSize}(bytes), heapSizeLimit: ${heapSizeLimit}(bytes)`);
+    const calculatedSize = Math.floor(totalAvailableSize * 0.5);
+    logger.debug(`Calculated buffer size: ${calculatedSize}(bytes), heapSizeLimit: ${totalAvailableSize}(bytes)`);
     return calculatedSize;
   }
 

--- a/packages/storage-service-clients/src/s3.ts
+++ b/packages/storage-service-clients/src/s3.ts
@@ -273,7 +273,7 @@ export class S3StorageServiceClient implements IStorageServiceClient {
     const { total_available_size: totalAvailableSize } = getHeapStatistics();
 
     const calculatedSize = Math.floor(totalAvailableSize * 0.5);
-    logger.debug(`Calculated buffer size: ${calculatedSize}(bytes), heapSizeLimit: ${totalAvailableSize}(bytes)`);
+    logger.debug(`Calculated buffer size: ${calculatedSize}(bytes), totalAvailableSize: ${totalAvailableSize}(bytes)`);
     return calculatedSize;
   }
 

--- a/packages/storage-service-clients/src/s3.ts
+++ b/packages/storage-service-clients/src/s3.ts
@@ -19,6 +19,7 @@ import {
   S3URI,
   S3StorageServiceClientConfig,
 } from './interfaces';
+import { PassThrough } from 'node:stream';
 
 /**
  * Client to manipulate S3 buckets
@@ -217,6 +218,11 @@ export class S3StorageServiceClient implements IStorageServiceClient {
     const destinationS3Uri = this._parseFilePath(destinationUri);
     if (destinationS3Uri == null) throw new Error(`URI ${destinationUri} is not correct S3's`);
 
+    const highWaterMark = this._partSizeCalculatedFromHeapSize() * this._queueSizeCalculatedFromCPU();
+    const adjuster = new PassThrough({
+      highWaterMark,
+    });
+
     const parallelUploads3 = new Upload({
       client: this.client,
       queueSize: this._queueSizeCalculatedFromCPU(),
@@ -225,7 +231,7 @@ export class S3StorageServiceClient implements IStorageServiceClient {
       params: {
         Bucket: destinationS3Uri.bucket,
         Key: path.join(destinationS3Uri.key, fileName),
-        Body: stream,
+        Body: adjuster,
       },
     });
 

--- a/packages/storage-service-clients/src/s3.ts
+++ b/packages/storage-service-clients/src/s3.ts
@@ -280,11 +280,11 @@ export class S3StorageServiceClient implements IStorageServiceClient {
   private _queueSizeCalculatedFromCPU() {
     // MUST BE A LESS THAN 10,000
     // see. https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html
-    const MIN_SIZE = 10000;
+    const MAX_SIZE = 10000;
 
     const calculatedSize = os.cpus().length * 2;
     logger.debug(`Calculated queue size: ${calculatedSize}`);
-    return Math.min(calculatedSize, MIN_SIZE);
+    return Math.min(calculatedSize, MAX_SIZE);
   }
 
 }

--- a/packages/storage-service-clients/src/s3.ts
+++ b/packages/storage-service-clients/src/s3.ts
@@ -272,7 +272,7 @@ export class S3StorageServiceClient implements IStorageServiceClient {
   private _bufferSizeCalculatedFromHeapSize() {
     const { heap_size_limit: heapSizeLimit } = getHeapStatistics();
 
-    const calculatedSize = Math.floor(heapSizeLimit * 0.4);
+    const calculatedSize = Math.floor(heapSizeLimit * 0.5);
     logger.debug(`Calculated buffer size: ${calculatedSize}(bytes), heapSizeLimit: ${heapSizeLimit}(bytes)`);
     return calculatedSize;
   }

--- a/packages/storage-service-clients/src/s3.ts
+++ b/packages/storage-service-clients/src/s3.ts
@@ -20,6 +20,9 @@ import {
   S3URI,
   S3StorageServiceClientConfig,
 } from './interfaces';
+import loggerFactory from './logger/factory';
+
+const logger = loggerFactory('storage-service-clients');
 
 /**
  * Client to manipulate S3 buckets
@@ -219,6 +222,7 @@ export class S3StorageServiceClient implements IStorageServiceClient {
     if (destinationS3Uri == null) throw new Error(`URI ${destinationUri} is not correct S3's`);
 
     const highWaterMark = this._partSizeCalculatedFromHeapSize() * this._queueSizeCalculatedFromCPU();
+    logger.debug(`Create PassThrough with highWaterMark: ${highWaterMark}(bytes)`);
     const adjuster = new PassThrough({
       highWaterMark,
     });
@@ -269,6 +273,7 @@ export class S3StorageServiceClient implements IStorageServiceClient {
     const MAX_SIZE = 5 * 1024 * 1024 * 1024;
 
     const calculatedSize = Math.floor(totalHeapSize * 0.5 / this._queueSizeCalculatedFromCPU());
+    logger.debug(`Calculated part size: ${calculatedSize}(bytes)`);
     return Math.min(Math.max(calculatedSize, MIN_SIZE), MAX_SIZE);
   }
 
@@ -278,6 +283,7 @@ export class S3StorageServiceClient implements IStorageServiceClient {
     const MIN_SIZE = 10000;
 
     const calculatedSize = os.cpus().length * 2;
+    logger.debug(`Calculated queue size: ${calculatedSize}`);
     return Math.min(calculatedSize, MIN_SIZE);
   }
 

--- a/packages/storage-service-clients/src/s3.ts
+++ b/packages/storage-service-clients/src/s3.ts
@@ -13,13 +13,13 @@ import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { promises as StreamPromises, Readable } from 'stream';
 import { getHeapStatistics } from 'v8';
 import path from 'node:path';
+import { PassThrough } from 'node:stream';
 import {
   IStorageServiceClient,
   listS3FilesOptions,
   S3URI,
   S3StorageServiceClientConfig,
 } from './interfaces';
-import { PassThrough } from 'node:stream';
 
 /**
  * Client to manipulate S3 buckets
@@ -231,7 +231,7 @@ export class S3StorageServiceClient implements IStorageServiceClient {
       params: {
         Bucket: destinationS3Uri.bucket,
         Key: path.join(destinationS3Uri.key, fileName),
-        Body: adjuster,
+        Body: stream.pipe(adjuster),
       },
     });
 


### PR DESCRIPTION
use total_available_size instead of total_heap_size
<!-- octocov -->
## Code Metrics Report
|                         | [master](https://github.com/weseek/awesome-database-backup/tree/master) ([303510d](https://github.com/weseek/awesome-database-backup/commit/303510d59b160c4f9c35539140d1dba032fab505)) | [imprv/tuning-performance-of-s3](https://github.com/weseek/awesome-database-backup/tree/imprv/tuning-performance-of-s3) ([dc2b15f](https://github.com/weseek/awesome-database-backup/commit/dc2b15f8b39e8106a4dd512e244aeb252e5ffb42)) |  +/-  |
|-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|------:|
| **Coverage**            |                                                                                                                                                                                  72.7% |                                                                                                                                                                                                                                  73.1% | +0.3% |
| **Code to Test Ratio**  |                                                                                                                                                                                  1:0.1 |                                                                                                                                                                                                                                  1:0.1 |  -0.1 |
| **Test Execution Time** |                                                                                                                                                                                  3m15s |                                                                                                                                                                                                                                  3m23s |   +8s |

<details>

<summary>Details</summary>

``` diff
  |                     | master (303510d) | imprv/tuning-performance-of-s3 |  +/-  |
  |                     |                  |           (dc2b15f)            |       |
  |---------------------|------------------|--------------------------------|-------|
+ | Coverage            |            72.7% |                          73.1% | +0.3% |
  |   Files             |               29 |                             29 |     0 |
  |   Lines             |              870 |                            889 |   +19 |
+ |   Covered           |              633 |                            650 |   +17 |
- | Code to Test Ratio  |            1:0.1 |                          1:0.1 |  -0.1 |
  |   Code              |            50723 |                          50765 |   +42 |
  |   Test              |             5103 |                           5103 |     0 |
- | Test Execution Time |            3m15s |                          3m23s |   +8s |
```

</details>


### Code coverage of files in pull request scope (96.8% → 97.0%)

|                                                                                                                      Files                                                                                                                       | Coverage |  +/-  |
|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------:|------:|
| [packages/storage-service-clients/src/config/logger/config.dev.ts](https://github.com/weseek/awesome-database-backup/blob/dc2b15f8b39e8106a4dd512e244aeb252e5ffb42/packages%2Fstorage-service-clients%2Fsrc%2Fconfig%2Flogger%2Fconfig.dev.ts)   | 100.0%   | 0.0%  |
| [packages/storage-service-clients/src/config/logger/config.prod.ts](https://github.com/weseek/awesome-database-backup/blob/dc2b15f8b39e8106a4dd512e244aeb252e5ffb42/packages%2Fstorage-service-clients%2Fsrc%2Fconfig%2Flogger%2Fconfig.prod.ts) | 100.0%   | 0.0%  |
| [packages/storage-service-clients/src/gcs.ts](https://github.com/weseek/awesome-database-backup/blob/dc2b15f8b39e8106a4dd512e244aeb252e5ffb42/packages%2Fstorage-service-clients%2Fsrc%2Fgcs.ts)                                                 | 100.0%   | 0.0%  |
| [packages/storage-service-clients/src/logger/factory.ts](https://github.com/weseek/awesome-database-backup/blob/dc2b15f8b39e8106a4dd512e244aeb252e5ffb42/packages%2Fstorage-service-clients%2Fsrc%2Flogger%2Ffactory.ts)                         | 100.0%   | 0.0%  |
| [packages/storage-service-clients/src/s3.ts](https://github.com/weseek/awesome-database-backup/blob/dc2b15f8b39e8106a4dd512e244aeb252e5ffb42/packages%2Fstorage-service-clients%2Fsrc%2Fs3.ts)                                                   | 94.8%    | +0.4% |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
