### PR TITLE
ci: update timeout setting in coverage report configuration

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -31,3 +31,4 @@ report:
   if: is_default_branch
   datastores:
   - artifact://${GITHUB_REPOSITORY}
+timeout: 1min


### PR DESCRIPTION

<!-- octocov -->
## Code Metrics Report
|                         | [master](https://github.com/weseek/awesome-database-backup/tree/master) ([a319621](https://github.com/weseek/awesome-database-backup/commit/a3196218423c20c4d7f418c5e4c0b6e1db4f1651)) | [support/expand-timeout-of-octocov](https://github.com/weseek/awesome-database-backup/tree/support/expand-timeout-of-octocov) ([e4a9644](https://github.com/weseek/awesome-database-backup/commit/e4a9644a1337e4eedf276258ef0c740199fa0d9d)) | +/-  |
|-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|-----:|
| **Coverage**            |                                                                                                                                                                                  73.1% |                                                                                                                                                                                                                                        73.1% | 0.0% |
| **Code to Test Ratio**  |                                                                                                                                                                                  1:0.1 |                                                                                                                                                                                                                                        1:0.1 |  0.0 |
| **Test Execution Time** |                                                                                                                                                                                  3m15s |                                                                                                                                                                                                                                        3m18s |  +3s |

<details>

<summary>Details</summary>

``` diff
  |                     | master (a319621) | support/expand-timeout-of-octocov | +/-  |
  |                     |                  |             (e4a9644)             |      |
  |---------------------|------------------|-----------------------------------|------|
  | Coverage            |            73.1% |                             73.1% | 0.0% |
  |   Files             |               29 |                                29 |    0 |
  |   Lines             |              889 |                               889 |    0 |
  |   Covered           |              650 |                               650 |    0 |
  | Code to Test Ratio  |            1:0.1 |                             1:0.1 |  0.0 |
  |   Code              |            50769 |                             50769 |    0 |
  |   Test              |             5101 |                              5101 |    0 |
- | Test Execution Time |            3m15s |                             3m18s |  +3s |
```

</details>



---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
