### PR TITLE
support: Use bitnamilegacy image

### DIFF
--- a/.github/workflows/app-benchmark.yaml
+++ b/.github/workflows/app-benchmark.yaml
@@ -87,7 +87,7 @@ jobs:
     services:
       minio:
         # set same version as minio/minio:RELEASE.2025-02-07T23-21-09Z
-        image: bitnami/minio:2025.2.7
+        image: bitnamilegacy/minio:2025.2.7
         ports:
         - 9000:9000
         options: >-


### PR DESCRIPTION
see https://github.com/bitnami/containers/issues/83267
<!-- octocov -->
## Code Metrics Report
|                         | [master](https://github.com/weseek/awesome-database-backup/tree/master) ([ced89c0](https://github.com/weseek/awesome-database-backup/commit/ced89c09de02b32e988bd47b9928a9466c601508)) | [support/use-legacy-bitnami-image](https://github.com/weseek/awesome-database-backup/tree/support/use-legacy-bitnami-image) ([d9f8ce2](https://github.com/weseek/awesome-database-backup/commit/d9f8ce2e34a017315d2d34ccbb7cd728c01b229c)) |  +/-  |
|-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|------:|
| **Coverage**            |                                                                                                                                                                                  73.3% |                                                                                                                                                                                                                                      73.1% | -0.3% |
| **Code to Test Ratio**  |                                                                                                                                                                                  1:0.1 |                                                                                                                                                                                                                                      1:0.1 |   0.0 |
| **Test Execution Time** |                                                                                                                                                                                  3m16s |                                                                                                                                                                                                                                      3m15s |   -1s |

<details>

<summary>Details</summary>

``` diff
  |                     | master (ced89c0) | support/use-legacy-bitnami-image |  +/-  |
  |                     |                  |            (d9f8ce2)             |       |
  |---------------------|------------------|----------------------------------|-------|
- | Coverage            |            73.3% |                            73.1% | -0.3% |
  |   Files             |               29 |                               29 |     0 |
  |   Lines             |              889 |                              889 |     0 |
- |   Covered           |              652 |                              650 |    -2 |
  | Code to Test Ratio  |            1:0.1 |                            1:0.1 |   0.0 |
  |   Code              |            50769 |                            50769 |     0 |
  |   Test              |             5101 |                             5101 |     0 |
+ | Test Execution Time |            3m16s |                            3m15s |   -1s |
```

</details>


### Code coverage of files in pull request scope (100.0% → 96.0%)

|                                                                     Files                                                                      | Coverage |  +/-  |  Status  |
|------------------------------------------------------------------------------------------------------------------------------------------------|---------:|------:|---------:|
| [src/commands/prune.ts](https://github.com/weseek/awesome-database-backup/blob/d9f8ce2e34a017315d2d34ccbb7cd728c01b229c/src/commands/prune.ts) | 96.0%    | -4.0% | affected |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
