### PR TITLE
support: Update release-drafter configuration to enable autolabeler

### DIFF
--- a/.github/workflows/misc-pr_to_master.yaml
+++ b/.github/workflows/misc-pr_to_master.yaml
@@ -17,11 +17,7 @@ jobs:
       !contains( github.event.pull_request.labels.*.name, 'flag/exclude-from-changelog' )
 
     steps:
-    - uses: release-drafter/release-drafter@v7
-      with:
-        disable-releaser: true
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - uses: release-drafter/release-drafter/autolabeler@v7
 
   misc-pr_to_master-check-title:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-update_draft.yaml
+++ b/.github/workflows/release-update_draft.yaml
@@ -31,7 +31,6 @@ jobs:
         name: v${{ steps.package-json.outputs.full }}
         tag: v${{ steps.package-json.outputs.full }}
         version: ${{ steps.package-json.outputs.full }}
-        disable-autolabeler: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This pull request updates our GitHub Actions workflows to improve the automation around pull request labeling and release drafting. The main changes involve switching to the `autolabeler` version of the Release Drafter action and adjusting related configuration.

**Workflow automation improvements:**

* Updated `.github/workflows/misc-pr_to_master.yaml` to use the `release-drafter/release-drafter/autolabeler@v7` action, enabling automatic labeling of pull requests instead of just drafting releases.
* Removed the `disable-autolabeler: true` configuration from `.github/workflows/release-update_draft.yaml`, allowing autolabeler functionality to be enabled for release drafts.
<!-- octocov -->
## Code Metrics Report
|                         | [master](https://github.com/weseek/awesome-database-backup/tree/master) ([e7519b2](https://github.com/weseek/awesome-database-backup/commit/e7519b22eefc3207899a2a0044ee61f2902a76a0)) | [fix/auto-releaser](https://github.com/weseek/awesome-database-backup/tree/fix/auto-releaser) ([5b54d85](https://github.com/weseek/awesome-database-backup/commit/5b54d85990c38e99d3e6eafb885666759e4115ea)) | +/-  |
|-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|-----:|
| **Coverage**            |                                                                                                                                                                                  71.8% |                                                                                                                                                                                                        71.8% | 0.0% |
| **Code to Test Ratio**  |                                                                                                                                                                                  1:0.1 |                                                                                                                                                                                                        1:0.1 |  0.0 |
| **Test Execution Time** |                                                                                                                                                                                  3m31s |                                                                                                                                                                                                        3m31s |   0s |

<details>

<summary>Details</summary>

``` diff
  |                     | master (e7519b2) | fix/auto-releaser (5b54d85) | +/-  |
  |---------------------|------------------|-----------------------------|------|
  | Coverage            |            71.8% |                       71.8% | 0.0% |
  |   Files             |               29 |                          29 |    0 |
  |   Lines             |              949 |                         949 |    0 |
  |   Covered           |              682 |                         682 |    0 |
  | Code to Test Ratio  |            1:0.1 |                       1:0.1 |  0.0 |
  |   Code              |            52026 |                       52026 |    0 |
  |   Test              |             5251 |                        5251 |    0 |
  | Test Execution Time |            3m31s |                       3m31s |   0s |
```

</details>



---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
