### PR TITLE
Imprv/mongodb/restore archive

### DIFF
--- a/apps/mongodb-restore/README.md
+++ b/apps/mongodb-restore/README.md
@@ -22,10 +22,32 @@ Options:
   --gcp-client-email <GCP_CLIENT_EMAIL>                                    GCP Client Email (env: GCP_CLIENT_EMAIL)
   --gcp-service-account-key-json-path <GCP_SERVICE_ACCOUNT_KEY_JSON_PATH>  JSON file path to your GCP Service Account Key (env: GCP_SERVICE_ACCOUNT_KEY_JSON_PATH)
   --restore-tool-options <OPTIONS_STRING>                                  pass options to restore tool exec (env: RESTORE_TOOL_OPTIONS)
+  --mongodb-archive-format                                                 restore from a MongoDB archive format backup file (env: MONGODB_ARCHIVE_FORMAT)
   -h, --help                                                               display help for command
 
 NOTICE:
   You can pass mongoDB options by set "--restore-tool-options". (ex. "--host db.example.com --username admin")
+```
+
+### Restoring a MongoDB archive format backup
+
+`mongodb-backup` stores backups in MongoDB archive format (created with `mongodump --archive`).
+To restore such a backup, add the `--mongodb-archive-format` flag:
+
+```
+restore \
+  --target-bucket-url s3://my-bucket/backup-20240101-120000.zst \
+  --mongodb-archive-format \
+  --restore-tool-options "--uri mongodb://root:password@mongo/?authSource=admin"
+```
+
+Or with the environment variable:
+
+```
+MONGODB_ARCHIVE_FORMAT=true \
+TARGET_BUCKET_URL=s3://my-bucket/backup-20240101-120000.zst \
+RESTORE_TOOL_OPTIONS="--uri mongodb://root:password@mongo/?authSource=admin" \
+restore
 ```
 
 ## Authentication

--- a/apps/mongodb-restore/__tests__/restore.test.ts
+++ b/apps/mongodb-restore/__tests__/restore.test.ts
@@ -8,14 +8,17 @@ import {
   testS3BucketURI,
   cleanTestS3Bucket,
   uploadMongoDBFixtureToTestS3Bucket,
+  uploadMongoDBArchiveFixtureToTestS3Bucket,
   storageConfig,
   testGCSBucketURI,
   initFakeGCSServer,
   cleanTestGCSBucket,
   uploadMongoDBFixtureToTestGCSBucket,
+  uploadMongoDBArchiveFixtureToTestGCSBucket,
 } from '@awesome-database-backup/storage-service-test';
 import {
   dropTestMongoDB,
+  prepareTestMongoDB,
   listCollectionNamesInTestMongoDB,
   mongodbURI,
   testMongoDBName,
@@ -71,6 +74,34 @@ describe('restore', () => {
     });
   });
 
+  describe('when valid S3 options are specified (archive format)', () => {
+    const objectURI = `${testS3BucketURI}/${testMongoDBName}.zst`;
+    const commandLine = `${execRestoreCommand} \
+      --aws-endpoint-url ${s3ClientConfig.endpoint} \
+      --aws-region ${s3ClientConfig.region} \
+      --aws-access-key-id ${s3ClientConfig.credentials.accessKeyId} \
+      --aws-secret-access-key ${s3ClientConfig.credentials.secretAccessKey} \
+      --restore-tool-options "--archive --uri ${mongodbURI}" \
+      --target-bucket-url ${objectURI}`;
+
+    beforeEach(cleanTestS3Bucket);
+    beforeEach(dropTestMongoDB);
+    beforeEach(prepareTestMongoDB);
+    beforeEach(async() => {
+      await uploadMongoDBArchiveFixtureToTestS3Bucket(testMongoDBName);
+    });
+    beforeEach(dropTestMongoDB);
+
+    it('restore mongo archive from S3 bucket', async() => {
+      expect(await listCollectionNamesInTestMongoDB()).toEqual([]);
+      expect(await exec(commandLine)).toEqual({
+        stdout: expect.stringMatching(/=== restore.ts started at .* ===/),
+        stderr: '',
+      });
+      expect(await listCollectionNamesInTestMongoDB()).toEqual(['dummy']);
+    });
+  });
+
   describe('when valid GCS options are specified', () => {
     const objectURI = `${testGCSBucketURI}/${testMongoDBName}.tar.zst`;
     const commandLine = `${execRestoreCommand} \
@@ -89,6 +120,35 @@ describe('restore', () => {
     });
 
     it('restore mongo in bucket', async() => {
+      expect(await listCollectionNamesInTestMongoDB()).toEqual([]);
+      expect(await exec(commandLine)).toEqual({
+        stdout: expect.stringMatching(/=== restore.ts started at .* ===/),
+        stderr: '',
+      });
+      expect(await listCollectionNamesInTestMongoDB()).toEqual(['dummy']);
+    });
+  });
+
+  describe('when valid GCS options are specified (archive format)', () => {
+    const objectURI = `${testGCSBucketURI}/${testMongoDBName}.zst`;
+    const commandLine = `${execRestoreCommand} \
+      --gcp-endpoint-url ${storageConfig.apiEndpoint} \
+      --gcp-project-id ${storageConfig.projectId} \
+      --gcp-client-email ${storageConfig.credentials.client_email} \
+      --gcp-private-key ${storageConfig.credentials.private_key} \
+      --restore-tool-options "--archive --uri ${mongodbURI}" \
+      --target-bucket-url ${objectURI}`;
+
+    beforeEach(initFakeGCSServer);
+    beforeEach(cleanTestGCSBucket);
+    beforeEach(dropTestMongoDB);
+    beforeEach(prepareTestMongoDB);
+    beforeEach(async() => {
+      await uploadMongoDBArchiveFixtureToTestGCSBucket(testMongoDBName);
+    });
+    beforeEach(dropTestMongoDB);
+
+    it('restore mongo archive from GCS bucket', async() => {
       expect(await listCollectionNamesInTestMongoDB()).toEqual([]);
       expect(await exec(commandLine)).toEqual({
         stdout: expect.stringMatching(/=== restore.ts started at .* ===/),

--- a/apps/mongodb-restore/__tests__/restore.test.ts
+++ b/apps/mongodb-restore/__tests__/restore.test.ts
@@ -81,7 +81,8 @@ describe('restore', () => {
       --aws-region ${s3ClientConfig.region} \
       --aws-access-key-id ${s3ClientConfig.credentials.accessKeyId} \
       --aws-secret-access-key ${s3ClientConfig.credentials.secretAccessKey} \
-      --restore-tool-options "--archive --uri ${mongodbURI}" \
+      --mongodb-archive-format \
+      --restore-tool-options "--uri ${mongodbURI}" \
       --target-bucket-url ${objectURI}`;
 
     beforeEach(cleanTestS3Bucket);
@@ -136,7 +137,8 @@ describe('restore', () => {
       --gcp-project-id ${storageConfig.projectId} \
       --gcp-client-email ${storageConfig.credentials.client_email} \
       --gcp-private-key ${storageConfig.credentials.private_key} \
-      --restore-tool-options "--archive --uri ${mongodbURI}" \
+      --mongodb-archive-format \
+      --restore-tool-options "--uri ${mongodbURI}" \
       --target-bucket-url ${objectURI}`;
 
     beforeEach(initFakeGCSServer);

--- a/apps/mongodb-restore/src/restore.ts
+++ b/apps/mongodb-restore/src/restore.ts
@@ -17,6 +17,12 @@ class MongoDBRestoreCommand extends RestoreCommand {
 
   async restoreDB(sourcePath: string, userSpecifiedOption?: string): Promise<{ stdout: string; stderr: string; }> {
     logger.info('restore MongoDB...');
+    // When --archive is specified, inject the temp file path as --archive=<path>
+    // because mongorestore treats the positional arg as a directory, conflicting with archive format
+    if (userSpecifiedOption != null && /--archive(?:=[^\s]*)?(?!\w)/.test(userSpecifiedOption)) {
+      const optionsWithPath = userSpecifiedOption.replace(/--archive(?:=[^\s]*)?(?!\w)/, `--archive=${sourcePath}`);
+      return exec(`mongorestore ${optionsWithPath}`);
+    }
     return exec(`mongorestore ${sourcePath} ${userSpecifiedOption}`);
   }
 

--- a/apps/mongodb-restore/src/restore.ts
+++ b/apps/mongodb-restore/src/restore.ts
@@ -4,6 +4,7 @@
  */
 import { exec as execOriginal } from 'child_process';
 import { promisify } from 'util';
+import { Option } from 'commander';
 import { RestoreCommand } from '@awesome-database-backup/commands';
 import loggerFactory from './logger/factory';
 
@@ -17,11 +18,10 @@ class MongoDBRestoreCommand extends RestoreCommand {
 
   async restoreDB(sourcePath: string, userSpecifiedOption?: string): Promise<{ stdout: string; stderr: string; }> {
     logger.info('restore MongoDB...');
-    // When --archive is specified, inject the temp file path as --archive=<path>
-    // because mongorestore treats the positional arg as a directory, conflicting with archive format
-    if (userSpecifiedOption != null && /--archive(?:=[^\s]*)?(?!\w)/.test(userSpecifiedOption)) {
-      const optionsWithPath = userSpecifiedOption.replace(/--archive(?:=[^\s]*)?(?!\w)/, `--archive=${sourcePath}`);
-      return exec(`mongorestore ${optionsWithPath}`);
+    // When --mongodb-archive is specified, pass the file path via --archive=<path>
+    // because mongorestore treats the positional arg as a directory, which conflicts with archive format
+    if (this.opts().mongodbArchiveFormat) {
+      return exec(`mongorestore --archive=${sourcePath} ${userSpecifiedOption ?? ''}`);
     }
     return exec(`mongorestore ${sourcePath} ${userSpecifiedOption}`);
   }
@@ -33,6 +33,10 @@ const restoreCommand = new MongoDBRestoreCommand();
 restoreCommand
   .version(version)
   .addRestoreOptions()
+  .addOption(
+    new Option('--mongodb-archive-format', 'restore from a MongoDB archive format backup file')
+      .env('MONGODB_ARCHIVE_FORMAT'),
+  )
   .addHelpText('after', `
     NOTICE:
       You can pass mongoDB options by set "--restore-tool-options". (ex. "--host db.example.com --username admin")

--- a/packages/mongodb-test/src/mongodb.ts
+++ b/packages/mongodb-test/src/mongodb.ts
@@ -3,12 +3,13 @@ import { MongoClient } from 'mongodb';
 import { BSON } from 'bsonfy';
 import { basename, join } from 'path';
 import {
-  writeFileSync, mkdirSync, createWriteStream,
+  writeFileSync, mkdirSync,
 } from 'fs';
-import * as StreamPromises from 'stream/promises';
+import { exec as execOriginal } from 'child_process';
+import { promisify } from 'util';
 import { mongodbURI } from './config/mongodb';
-import { createGzip } from 'zlib';
 
+const exec = promisify(execOriginal);
 const tar = require('tar');
 const tmp = require('tmp');
 
@@ -85,4 +86,14 @@ export function createMongoDBBackup(fileName: string): string {
   );
 
   return docBackupedFilePath;
+}
+
+export async function createMongoDBArchiveBackup(fileName: string): Promise<string> {
+  const tmpdir = tmp.dirSync({ unsafeCleanup: true });
+  const archivePath = join(tmpdir.name, `${fileName}.zst`);
+  await exec(
+    `set -o pipefail; mongodump --archive --uri ${mongodbURI} --db ${testMongoDBName} | zstd > ${archivePath}`,
+    { shell: '/bin/bash' },
+  );
+  return archivePath;
 }

--- a/packages/storage-service-test/src/fake-gcs-server.ts
+++ b/packages/storage-service-test/src/fake-gcs-server.ts
@@ -1,6 +1,6 @@
 import { Storage } from '@google-cloud/storage';
 import { createPGBackup } from '@awesome-database-backup/postgresql-test';
-import { createMongoDBBackup } from '@awesome-database-backup/mongodb-test';
+import { createMongoDBBackup, createMongoDBArchiveBackup } from '@awesome-database-backup/mongodb-test';
 import { createMariaDBBackup } from '@awesome-database-backup/mariadb-test';
 import { createFileBackup } from '@awesome-database-backup/file-test';
 import { basename } from 'path';
@@ -47,6 +47,13 @@ export async function uploadMongoDBFixtureToTestGCSBucket(fixtureName: string): 
       destination: basename(fixturePath),
     },
   );
+}
+
+export async function uploadMongoDBArchiveFixtureToTestGCSBucket(fixtureName: string): Promise<void> {
+  const fixturePath = await createMongoDBArchiveBackup(fixtureName);
+  await storage.bucket(testGCSBucketName).upload(fixturePath, {
+    destination: basename(fixturePath),
+  });
 }
 
 export async function uploadMariaDBFixtureToTestGCSBucket(fixtureName: string): Promise<void> {

--- a/packages/storage-service-test/src/minio.ts
+++ b/packages/storage-service-test/src/minio.ts
@@ -9,7 +9,7 @@ import {
 } from '@aws-sdk/client-s3';
 import { readFileSync } from 'fs';
 import { createPGBackup } from '@awesome-database-backup/postgresql-test';
-import { createMongoDBBackup } from '@awesome-database-backup/mongodb-test';
+import { createMongoDBBackup, createMongoDBArchiveBackup } from '@awesome-database-backup/mongodb-test';
 import { createMariaDBBackup } from '@awesome-database-backup/mariadb-test';
 import { createFileBackup } from '@awesome-database-backup/file-test';
 import { basename } from 'path';
@@ -41,6 +41,15 @@ export async function uploadPGFixtureToTestS3Bucket(fixtureName: string): Promis
 
 export async function uploadMongoDBFixtureToTestS3Bucket(fixtureName: string): Promise<void> {
   const fixturePath = createMongoDBBackup(fixtureName);
+  await s3client.send(new PutObjectCommand({
+    Bucket: testS3BucketName,
+    Key: basename(fixturePath),
+    Body: readFileSync(fixturePath),
+  }));
+}
+
+export async function uploadMongoDBArchiveFixtureToTestS3Bucket(fixtureName: string): Promise<void> {
+  const fixturePath = await createMongoDBArchiveBackup(fixtureName);
   await s3client.send(new PutObjectCommand({
     Bucket: testS3BucketName,
     Key: basename(fixturePath),


### PR DESCRIPTION
This pull request adds support for restoring MongoDB backups stored in the MongoDB archive format (created with `mongodump --archive`) from both S3 and GCS buckets. It introduces a new `--mongodb-archive-format` flag to the restore CLI, updates documentation, and adds comprehensive tests for this new functionality.

**MongoDB archive format support:**

* Added a new `--mongodb-archive-format` CLI flag and corresponding `MONGODB_ARCHIVE_FORMAT` environment variable to `restore.ts`, allowing users to restore from MongoDB archive format backup files. When this flag is set, the restore command uses `mongorestore --archive=<path>` instead of treating the backup as a directory. [[1]](diffhunk://#diff-9b2cbf4c9eb8f64e0cbebd1dd02e192e642c8091a2bf0987ea8088caca20209bR21-R25) [[2]](diffhunk://#diff-9b2cbf4c9eb8f64e0cbebd1dd02e192e642c8091a2bf0987ea8088caca20209bR36-R39)
* Updated the `README.md` to document the new flag and provide usage examples for restoring from MongoDB archive format backups.

**Test enhancements:**

* Added new test cases in `restore.test.ts` to verify restoring MongoDB archive format backups from both S3 and GCS buckets, including new helpers for uploading archive-format fixtures. [[1]](diffhunk://#diff-cc4c3b51845fb3c8916259c35751fa0a2531870c55c471c215bb637fd4f0841bR11-R21) [[2]](diffhunk://#diff-cc4c3b51845fb3c8916259c35751fa0a2531870c55c471c215bb637fd4f0841bR77-R105) [[3]](diffhunk://#diff-cc4c3b51845fb3c8916259c35751fa0a2531870c55c471c215bb637fd4f0841bR132-R161)
* Implemented `createMongoDBArchiveBackup` in `mongodb.ts` to generate MongoDB archive format backups, and added corresponding upload helpers for S3 and GCS test buckets. [[1]](diffhunk://#diff-49177145be81897b61989d282758055efbada104bfb9c299d378aa9df1dce3d9R90-R99) [[2]](diffhunk://#diff-d76299ad87f00f2df3e1245125cd688691c72b04f03bd030b275646bb4e418ceL3-R3) [[3]](diffhunk://#diff-d76299ad87f00f2df3e1245125cd688691c72b04f03bd030b275646bb4e418ceR52-R58) [[4]](diffhunk://#diff-43ed40c6135df5b1235012109bad474d88bd3e848644f7a239a4c8501fc399e6L12-R12) [[5]](diffhunk://#diff-43ed40c6135df5b1235012109bad474d88bd3e848644f7a239a4c8501fc399e6R51-R59)