### PR TITLE
support: Update benchmark workflow triggers for pull requests and schedules

### DIFF
--- a/.github/workflows/app-benchmark.yaml
+++ b/.github/workflows/app-benchmark.yaml
@@ -1,10 +1,15 @@
 name: Application - Benchmark
 
 on:
-  push:
+  pull_request:
+    types: [labeled]
+  workflow_dispatch:
+  schedule:
+  - cron: '0 0 * * 1'  # Every Monday at 00:00 UTC
 
 jobs:
   benchmark-with-gcs:
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.label.name == 'needs-benchmark'
     permissions:
       actions: read
       pull-requests: write
@@ -67,6 +72,7 @@ jobs:
         NODE_OPTIONS: '--max-old-space-size=${{ matrix.node-js-heap-size }}'
 
   benchmark-with-s3:
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.label.name == 'needs-benchmark'
     permissions:
       actions: read
       pull-requests: write


### PR DESCRIPTION
This pull request updates the `app-benchmark.yaml` GitHub Actions workflow to improve when and how benchmarks are triggered. The workflow now runs benchmarks more flexibly, including on scheduled intervals, manual dispatch, and when a pull request is labeled as needing a benchmark.

**Workflow trigger and execution improvements:**

* Changed the workflow to trigger on pull request label events, manual dispatch, and a scheduled weekly cron job, instead of only on push events. (`.github/workflows/app-benchmark.yaml`)
* Added conditional checks to both `benchmark-with-gcs` and `benchmark-with-s3` jobs to ensure they only run for workflow dispatch, scheduled runs, or when the pull request is labeled `needs-benchmark`. (`.github/workflows/app-benchmark.yaml`) [[1]](diffhunk://#diff-3f83d4b816165dc78dff9944acf7c6c29640a7a1d2193316ec70f33951030f81L4-R12) [[2]](diffhunk://#diff-3f83d4b816165dc78dff9944acf7c6c29640a7a1d2193316ec70f33951030f81R75)