### PR TITLE
support: Add test for aws path style option

### DIFF
--- a/packages/commands/__tests__/commands/common.test.ts
+++ b/packages/commands/__tests__/commands/common.test.ts
@@ -28,9 +28,11 @@ describe('StorageServiceClientCommand', () => {
         expect(option?.defaultValue).toBe(false);
       });
 
-      it('defaults to false', () => {
+      it('parses to false when neither the flag nor the env var is set', () => {
         const command = new StorageServiceClientCommand();
-        command.addStorageOptions();
+        // command.opts() is only reliable after parse() has run in commander
+        // (defaults are applied during parsing).
+        command.addStorageOptions().parse(['--target-bucket-url', 's3://bucket'], { from: 'user' });
 
         expect(command.opts().awsForcePathStyle).toBe(false);
       });

--- a/packages/commands/__tests__/commands/common.test.ts
+++ b/packages/commands/__tests__/commands/common.test.ts
@@ -1,5 +1,5 @@
 import {
-  vi, describe, it, expect,
+  vi, describe, it, expect, afterEach,
 } from 'vitest';
 import { StorageServiceClientCommand } from '../../src/commands/common';
 
@@ -10,6 +10,46 @@ describe('StorageServiceClientCommand', () => {
       vi.spyOn(command, 'addOption');
       expect(command.addStorageOptions()).toBe(command);
       expect(command.addOption).toBeCalled();
+    });
+
+    describe('--aws-force-path-style / AWS_FORCE_PATH_STYLE option', () => {
+      afterEach(() => {
+        delete process.env.AWS_FORCE_PATH_STYLE;
+      });
+
+      it('registers an option bound to the AWS_FORCE_PATH_STYLE env var, defaulting to false', () => {
+        const command = new StorageServiceClientCommand();
+        command.addStorageOptions();
+
+        const option = command.options.find(opt => opt.attributeName() === 'awsForcePathStyle');
+        expect(option).toBeDefined();
+        expect(option?.long).toBe('--aws-force-path-style');
+        expect(option?.envVar).toBe('AWS_FORCE_PATH_STYLE');
+        expect(option?.defaultValue).toBe(false);
+      });
+
+      it('defaults to false', () => {
+        const command = new StorageServiceClientCommand();
+        command.addStorageOptions();
+
+        expect(command.opts().awsForcePathStyle).toBe(false);
+      });
+
+      it('parses to true when the --aws-force-path-style flag is passed', () => {
+        const command = new StorageServiceClientCommand();
+        command.addStorageOptions().parse(['--target-bucket-url', 's3://bucket', '--aws-force-path-style'], { from: 'user' });
+
+        expect(command.opts().awsForcePathStyle).toBe(true);
+      });
+
+      it('parses to true when the AWS_FORCE_PATH_STYLE env var is set', () => {
+        process.env.AWS_FORCE_PATH_STYLE = 'true';
+
+        const command = new StorageServiceClientCommand();
+        command.addStorageOptions().parse(['--target-bucket-url', 's3://bucket'], { from: 'user' });
+
+        expect(command.opts().awsForcePathStyle).toBe(true);
+      });
     });
   });
 

--- a/packages/storage-service-clients/__tests__/s3.test.ts
+++ b/packages/storage-service-clients/__tests__/s3.test.ts
@@ -116,6 +116,41 @@ describe('S3StorageServiceClient', () => {
       });
     });
 
+    describe('when config has awsForcePathStyle set to true', () => {
+      const config: S3StorageServiceClientConfig = {
+        awsRegion: 'us-east-1',
+        awsEndpointUrl: new URL('https://custom-endpoint.example.com'),
+        awsForcePathStyle: true,
+      };
+
+      it('sets forcePathStyle to true in S3Client config', async() => {
+        const { S3StorageServiceClient } = await import('../src/s3');
+        expect(() => new S3StorageServiceClient(config)).not.toThrow();
+        expect(S3ClientMock).toHaveBeenCalledWith({
+          region: 'us-east-1',
+          endpoint: 'https://custom-endpoint.example.com/',
+          forcePathStyle: true,
+          credentials: {},
+        });
+      });
+    });
+
+    describe('when config has awsForcePathStyle set to false', () => {
+      const config: S3StorageServiceClientConfig = {
+        awsRegion: 'us-east-1',
+        awsForcePathStyle: false,
+      };
+
+      it('does not set forcePathStyle in S3Client config', async() => {
+        const { S3StorageServiceClient } = await import('../src/s3');
+        expect(() => new S3StorageServiceClient(config)).not.toThrow();
+        expect(S3ClientMock).toHaveBeenCalledWith({
+          region: 'us-east-1',
+          credentials: {},
+        });
+      });
+    });
+
     describe('when using STS with WebIdentity token', () => {
       beforeEach(() => {
         // Set environment variables for STS


### PR DESCRIPTION
…ntCommand and S3StorageServiceClient
<!-- octocov -->
## Code Metrics Report
|                         | [master](https://github.com/weseek/awesome-database-backup/tree/master) ([d3565b4](https://github.com/weseek/awesome-database-backup/commit/d3565b45ddde47ff0f6543036eb2988838df96ab)) | [support/add-test-for-aws-path-style-option](https://github.com/weseek/awesome-database-backup/tree/support/add-test-for-aws-path-style-option) ([3b4789a](https://github.com/weseek/awesome-database-backup/commit/3b4789ad5cc814d92a9bdaa8a65d853047fe5f75)) |  +/-  |
|-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|------:|
| **Coverage**            |                                                                                                                                                                                  71.1% |                                                                                                                                                                                                                                                          71.3% | +0.2% |
| **Code to Test Ratio**  |                                                                                                                                                                                  1:0.1 |                                                                                                                                                                                                                                                          1:0.1 |  +0.0 |
| **Test Execution Time** |                                                                                                                                                                                  3m39s |                                                                                                                                                                                                                                                          3m37s |   -2s |

<details>

<summary>Details</summary>

``` diff
  |                     | master (d3565b4) | support/add-test-for-aws-path-style-option |  +/-  |
  |                     |                  |                 (3b4789a)                  |       |
  |---------------------|------------------|--------------------------------------------|-------|
+ | Coverage            |            71.1% |                                      71.3% | +0.2% |
  |   Files             |               29 |                                         29 |     0 |
  |   Lines             |              956 |                                        956 |     0 |
+ |   Covered           |              680 |                                        682 |    +2 |
+ | Code to Test Ratio  |            1:0.1 |                                      1:0.1 |  +0.0 |
  |   Code              |            52059 |                                      52059 |     0 |
+ |   Test              |             5307 |                                       5368 |   +61 |
+ | Test Execution Time |            3m39s |                                      3m37s |   -2s |
```

</details>


### Code coverage of files in pull request scope (94.8% → 95.8%)

|                                                                                          Files                                                                                           | Coverage |  +/-  |  Status  |
|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------:|------:|---------:|
| [packages/storage-service-clients/src/s3.ts](https://github.com/weseek/awesome-database-backup/blob/3b4789ad5cc814d92a9bdaa8a65d853047fe5f75/packages/storage-service-clients/src/s3.ts) | 95.8%    | +1.0% | affected |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
