### PR TITLE
support: Update Node.js version to 24 across all relevant files

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 
 # You must set same Node.js version and Linux distribution as docker/Dockerfile
 # [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
-ARG VARIANT="22"
+ARG VARIANT="24"
 FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:dev-${VARIANT}-bullseye
 
 # [Optional] Uncomment this section to install additional OS packages.

--- a/apps/file-backup/package.json
+++ b/apps/file-backup/package.json
@@ -54,7 +54,7 @@
     "@types/bunyan": "catalog:"
   },
   "engines": {
-    "node": ">= 22 < 23",
+    "node": ">= 24 < 25",
     "pnpm": ">= 11"
   }
 }

--- a/apps/file-restore/package.json
+++ b/apps/file-restore/package.json
@@ -44,7 +44,7 @@
     "@types/bunyan": "catalog:"
   },
   "engines": {
-    "node": ">= 22 < 23",
+    "node": ">= 24 < 25",
     "pnpm": ">= 11"
   }
 }

--- a/apps/list/package.json
+++ b/apps/list/package.json
@@ -43,7 +43,7 @@
     "@types/bunyan": "catalog:"
   },
   "engines": {
-    "node": ">= 22 < 23",
+    "node": ">= 24 < 25",
     "pnpm": ">= 11"
   }
 }

--- a/apps/mariadb-backup/package.json
+++ b/apps/mariadb-backup/package.json
@@ -45,7 +45,7 @@
     "@types/bunyan": "catalog:"
   },
   "engines": {
-    "node": ">= 22 < 23",
+    "node": ">= 24 < 25",
     "pnpm": ">= 11"
   }
 }

--- a/apps/mariadb-restore/package.json
+++ b/apps/mariadb-restore/package.json
@@ -44,7 +44,7 @@
     "@types/bunyan": "catalog:"
   },
   "engines": {
-    "node": ">= 22 < 23",
+    "node": ">= 24 < 25",
     "pnpm": ">= 11"
   }
 }

--- a/apps/mongodb-backup/package.json
+++ b/apps/mongodb-backup/package.json
@@ -45,7 +45,7 @@
     "@types/bunyan": "catalog:"
   },
   "engines": {
-    "node": ">= 22 < 23",
+    "node": ">= 24 < 25",
     "pnpm": ">= 11"
   }
 }

--- a/apps/mongodb-restore/package.json
+++ b/apps/mongodb-restore/package.json
@@ -44,7 +44,7 @@
     "@types/bunyan": "catalog:"
   },
   "engines": {
-    "node": ">= 22 < 23",
+    "node": ">= 24 < 25",
     "pnpm": ">= 11"
   }
 }

--- a/apps/postgresql-backup/package.json
+++ b/apps/postgresql-backup/package.json
@@ -45,7 +45,7 @@
     "@types/bunyan": "catalog:"
   },
   "engines": {
-    "node": ">= 22 < 23",
+    "node": ">= 24 < 25",
     "pnpm": ">= 11"
   }
 }

--- a/apps/postgresql-restore/package.json
+++ b/apps/postgresql-restore/package.json
@@ -44,7 +44,7 @@
     "@types/bunyan": "catalog:"
   },
   "engines": {
-    "node": ">= 22 < 23",
+    "node": ">= 24 < 25",
     "pnpm": ">= 11"
   }
 }

--- a/apps/prune/package.json
+++ b/apps/prune/package.json
@@ -44,7 +44,7 @@
     "@types/bunyan": "catalog:"
   },
   "engines": {
-    "node": ">= 22 < 23",
+    "node": ">= 24 < 25",
     "pnpm": ">= 11"
   }
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@ ARG dbType
 ARG COREPACK_VERSION=0.34.6
 
 # You should set same Node.js version and Linux distribution as .devcontainer/Dockerfile
-FROM node:22.13.1-bullseye-slim AS base
+FROM node:24.18.0-bullseye-slim AS base
 
 ##
 ## Prepare a subset of this monorepo

--- a/misc/bump-versions/package.json
+++ b/misc/bump-versions/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
   },
   "engines": {
-    "node": ">= 22 < 23",
+    "node": ">= 24 < 25",
     "pnpm": ">= 11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "dependencies": {},
   "devDependencies": {
-    "@types/node": "^22",
+    "@types/node": "^24",
     "@typescript-eslint/eslint-plugin": "^5.22.0",
     "@typescript-eslint/parser": "^5.22.0",
     "@vitest/coverage-v8": "^3.0.8",
@@ -47,7 +47,7 @@
     "bump-version:patch": "pnpm run bump-version -- -i patch"
   },
   "engines": {
-    "node": ">= 22 < 23",
+    "node": ">= 24 < 25",
     "pnpm": ">= 11"
   },
   "packageManager": "pnpm@11.9.0"

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -48,7 +48,7 @@
     "cross-env": "catalog:"
   },
   "engines": {
-    "node": ">= 22 < 23",
+    "node": ">= 24 < 25",
     "pnpm": ">= 11"
   }
 }

--- a/packages/common-tsconfig/tsconfig.base.json
+++ b/packages/common-tsconfig/tsconfig.base.json
@@ -1,6 +1,4 @@
 {
-  "lib": "es2019",
-
   /* default compiler options */
   "compilerOptions": {
     "strict": true,
@@ -10,7 +8,8 @@
     "sourceMap": true,
     "noEmit": false,
     "inlineSources": true,
-    "target": "es2019",
+    "target": "es2022",
+    "lib": ["es2022"],
     "module": "commonjs",
 
     /*

--- a/packages/storage-service-clients/package.json
+++ b/packages/storage-service-clients/package.json
@@ -45,7 +45,7 @@
     "cross-env": "catalog:"
   },
   "engines": {
-    "node": ">= 22 < 23",
+    "node": ">= 24 < 25",
     "pnpm": ">= 11"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
   .:
     devDependencies:
       '@types/node':
-        specifier: ^22
-        version: 22.19.17
+        specifier: ^24
+        version: 24.13.2
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.22.0
         version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
@@ -103,7 +103,7 @@ importers:
         version: 3.0.2
       ts-node:
         specifier: ^10.7.0
-        version: 10.9.2(@types/node@22.19.17)(typescript@5.9.3)
+        version: 10.9.2(@types/node@24.13.2)(typescript@5.9.3)
       ts-node-dev:
         specifier: ^1.1.8
         version: 1.1.8(typescript@5.9.3)
@@ -118,7 +118,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.8
-        version: 3.2.4(@types/node@22.19.17)(@vitest/ui@3.2.4)
+        version: 3.2.4(@types/node@24.13.2)(@vitest/ui@3.2.4)
       vitest-ctrf-json-reporter:
         specifier: ^0.0.2
         version: 0.0.2
@@ -1741,6 +1741,9 @@ packages:
 
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
+  '@types/node@24.13.2':
+    resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -4527,6 +4530,9 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
   universal-bunyan@0.9.2:
     resolution: {integrity: sha512-MkyO17+5AVCpFfhMtYLODvSZmPxV8eHcoOAWobEXXzlXrSnf5YgCV5lBWcMV3VPaaKyZPQ0oG5PSWYmGSBGtIg==}
     peerDependencies:
@@ -6141,6 +6147,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@24.13.2':
+    dependencies:
+      undici-types: 7.18.2
+
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/pg@8.20.0':
@@ -6274,7 +6284,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@22.19.17)(@vitest/ui@3.2.4)
+      vitest: 3.2.4(@types/node@24.13.2)(@vitest/ui@3.2.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -6284,7 +6294,7 @@ snapshots:
       eslint: 8.57.1
     optionalDependencies:
       typescript: 5.9.3
-      vitest: 3.2.4(@types/node@22.19.17)(@vitest/ui@3.2.4)
+      vitest: 3.2.4(@types/node@24.13.2)(@vitest/ui@3.2.4)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -6294,13 +6304,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@22.19.17))':
+  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@24.13.2))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2(@types/node@22.19.17)
+      vite: 7.3.2(@types/node@24.13.2)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -6331,7 +6341,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@22.19.17)(@vitest/ui@3.2.4)
+      vitest: 3.2.4(@types/node@24.13.2)(@vitest/ui@3.2.4)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -9264,14 +9274,14 @@ snapshots:
       tsconfig: 7.0.0
       typescript: 5.9.3
 
-  ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3):
+  ts-node@10.9.2(@types/node@24.13.2)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.19.17
+      '@types/node': 24.13.2
       acorn: 8.16.0
       acorn-walk: 8.3.5
       arg: 4.1.3
@@ -9406,6 +9416,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici-types@7.18.2: {}
+
   universal-bunyan@0.9.2(@browser-bunyan/console-formatted-stream@1.8.0)(browser-bunyan@1.8.0)(bunyan@1.8.15):
     dependencies:
       '@browser-bunyan/console-formatted-stream': 1.8.0
@@ -9447,13 +9459,13 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
-  vite-node@3.2.4(@types/node@22.19.17):
+  vite-node@3.2.4(@types/node@24.13.2):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.2(@types/node@22.19.17)
+      vite: 7.3.2(@types/node@24.13.2)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -9468,7 +9480,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.2(@types/node@22.19.17):
+  vite@7.3.2(@types/node@24.13.2):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -9477,7 +9489,7 @@ snapshots:
       rollup: 4.60.2
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 22.19.17
+      '@types/node': 24.13.2
       fsevents: 2.3.3
 
   vitest-ctrf-json-reporter@0.0.2: {}
@@ -9486,13 +9498,13 @@ snapshots:
     dependencies:
       ts-essentials: 10.1.1(typescript@5.9.3)
       typescript: 5.9.3
-      vitest: 3.2.4(@types/node@22.19.17)(@vitest/ui@3.2.4)
+      vitest: 3.2.4(@types/node@24.13.2)(@vitest/ui@3.2.4)
 
-  vitest@3.2.4(@types/node@22.19.17)(@vitest/ui@3.2.4):
+  vitest@3.2.4(@types/node@24.13.2)(@vitest/ui@3.2.4):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@22.19.17))
+      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@24.13.2))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -9510,11 +9522,11 @@ snapshots:
       tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.2(@types/node@22.19.17)
-      vite-node: 3.2.4(@types/node@22.19.17)
+      vite: 7.3.2(@types/node@24.13.2)
+      vite-node: 3.2.4(@types/node@24.13.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.19.17
+      '@types/node': 24.13.2
       '@vitest/ui': 3.2.4(vitest@3.2.4)
     transitivePeerDependencies:
       - jiti


### PR DESCRIPTION
This pull request upgrades the project to require Node.js 24 across all apps, packages, and development environments. It updates the Node.js version used in Dockerfiles, development containers, and all relevant `package.json` files. Additionally, it bumps the `@types/node` dependency to version 24 and updates the `pnpm-lock.yaml` file to reflect these changes and their transitive dependencies.

**Node.js Version Upgrade:**

* Updated Node.js version requirement to `>= 24 < 25` in all `package.json` files for apps and packages, ensuring consistency across the monorepo. [[1]](diffhunk://#diff-57e911fc99a33f92b5835a469879fc8de29747a4f28349ca8940681e359d9e1dL57-R57) [[2]](diffhunk://#diff-28f371ef9d5c7438f1a69eb838ad5e03a44f69f84d76d6646b690b77cc63d5edL47-R47) [[3]](diffhunk://#diff-213f20b019dc273abbb83077c9da8ed2be6755f44eb3fdc422d93ef3061bf4b5L46-R46) [[4]](diffhunk://#diff-1889dd95657b9ec2bf6a97c8ef2c016717acc491d9bad496443d3709be0417f7L48-R48) [[5]](diffhunk://#diff-48e3ae8ea73317521fd0940d404417a67ed704ab96210d337652e070ccb0afaeL47-R47) [[6]](diffhunk://#diff-7c32b1a1fa684a374697d7a871d660a8b3dceff24f97e3915a5a75eae88ee550L48-R48) [[7]](diffhunk://#diff-fb5ab8eb2deeb09897f4188d380749f010e43bf0ceb22f557eb66d8504943aa7L47-R47) [[8]](diffhunk://#diff-6daf9631fd94586f6bbb287a187262b9542a14fa1412e97ae004d8b53406604dL48-R48) [[9]](diffhunk://#diff-8ef7700c2420318cd3c447ee6c0c5ed39d665a979ec2a8226cf9d365710a7faeL47-R47) [[10]](diffhunk://#diff-efaa34a97cc527892f70c764cc9a49bb4d4e0f76fa570296e90a4a9e62d9b4c0L47-R47) [[11]](diffhunk://#diff-5eeb7ccf0e9f58bae78b8826867f66c1704e430ee2c13cf562a10720d607a7efL28-R28) [[12]](diffhunk://#diff-902c77cd26d157dc54961d80f50707c1483ef762d1d47ff920e23437e1f769a4L51-R51) [[13]](diffhunk://#diff-c9b887fa9c04dd801f6fd3d37ed7d6bd856ab46b224a01ea532b706dd5a4e421L48-R48) [[14]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L50-R50)
* Changed the base image in `docker/Dockerfile` and `.devcontainer/Dockerfile` to use Node.js 24. [[1]](diffhunk://#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddcL8-R8) [[2]](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6L5-R5)

**Type Definitions and Tooling:**

* Upgraded `@types/node` to version 24 in `package.json` and `pnpm-lock.yaml`, along with associated dependency snapshots. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L12-R12) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL66-R67) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1745-R1747)
* Updated references to `@types/node@24.13.2` in all relevant dependency graphs and transitive dependencies in `pnpm-lock.yaml`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL106-R106) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL121-R121) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR6150-R6153) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL6277-R6287) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL6287-R6297) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL6297-R6313) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL6334-R6344) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9267-R9284) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9450-R9468) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9471-R9483) [[11]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9480-R9492) [[12]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9489-R9507) [[13]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9513-R9529)

**Dependency Updates:**

* Updated `undici-types` to version 7.18.2 as a new dependency of `@types/node@24.13.2`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4533-R4535) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR9419-R9420)

These changes ensure the codebase is ready for Node.js 24 and that all dependencies and development environments are aligned.
<!-- octocov -->
## Code Metrics Report
|                         | [master](https://github.com/weseek/awesome-database-backup/tree/master) ([fd30783](https://github.com/weseek/awesome-database-backup/commit/fd307832e961a3739d75abc7dfeb56b5af0ec32f)) | [support/update-nodejs-to-24](https://github.com/weseek/awesome-database-backup/tree/support/update-nodejs-to-24) ([871e1e5](https://github.com/weseek/awesome-database-backup/commit/871e1e577f979941b0ab8098997a7b47cc6ce347)) |  +/-  |
|-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|------:|
| **Coverage**            |                                                                                                                                                                                  69.7% |                                                                                                                                                                                                                            70.0% | +0.2% |
| **Code to Test Ratio**  |                                                                                                                                                                                  1:0.0 |                                                                                                                                                                                                                            1:0.0 |   0.0 |
| **Test Execution Time** |                                                                                                                                                                                  3m51s |                                                                                                                                                                                                                            3m24s |  -27s |

<details>

<summary>Details</summary>

``` diff
  |                     | master (fd30783) |  support/update-nodejs-to-24   |  +/-  |
  |                     |                  |           (871e1e5)            |       |
  |---------------------|------------------|--------------------------------|-------|
+ | Coverage            |            69.7% |                          70.0% | +0.2% |
  |   Files             |               30 |                             30 |     0 |
  |   Lines             |              979 |                            987 |    +8 |
+ |   Covered           |              683 |                            691 |    +8 |
  | Code to Test Ratio  |            1:0.0 |                          1:0.0 |   0.0 |
  |   Code              |            49401 |                          49401 |     0 |
  |   Test              |             4830 |                           4830 |     0 |
+ | Test Execution Time |            3m51s |                          3m24s |  -27s |
```

</details>


### Code coverage of files in pull request scope (85.5% → 85.6%)

|                                                                                          Files                                                                                           | Coverage |  +/-  |  Status  |
|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------:|------:|---------:|
| [packages/commands/src/commands/backup.ts](https://github.com/weseek/awesome-database-backup/blob/871e1e577f979941b0ab8098997a7b47cc6ce347/packages/commands/src/commands/backup.ts)     | 89.2%    | +0.0% | affected |
| [packages/commands/src/commands/common.ts](https://github.com/weseek/awesome-database-backup/blob/871e1e577f979941b0ab8098997a7b47cc6ce347/packages/commands/src/commands/common.ts)     | 94.3%    | +0.0% | affected |
| [packages/commands/src/commands/restore.ts](https://github.com/weseek/awesome-database-backup/blob/871e1e577f979941b0ab8098997a7b47cc6ce347/packages/commands/src/commands/restore.ts)   | 55.7%    | +0.4% | affected |
| [packages/storage-service-clients/src/s3.ts](https://github.com/weseek/awesome-database-backup/blob/871e1e577f979941b0ab8098997a7b47cc6ce347/packages/storage-service-clients/src/s3.ts) | 95.8%    | +0.0% | affected |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
