### PR TITLE
support: Remove deprecated NODE_OPTIONS from test job

### DIFF
--- a/.github/workflows/app-test.yaml
+++ b/.github/workflows/app-test.yaml
@@ -37,12 +37,6 @@ jobs:
     - name: Run test
       run:
         docker compose -f .devcontainer/compose.yml exec -e NODE_OPTIONS -e CI -T -- node bash -c 'pnpm install --frozen-lockfile && pnpm test'
-      env:
-        # Temporarily ignore warnings
-        # see:
-        # * https://github.com/nodejs/node/blob/59cdd4f1c246cceb89a00c37e3c819a08444c888/doc/api/deprecations.md#dep0040-nodepunycode-module
-        # * https://github.com/nodejs/node/pull/56632
-        NODE_OPTIONS: --no-deprecation
 
     - name: Show test report to result of action
       if: success() || failure()


### PR DESCRIPTION
This pull request makes a small change to the GitHub Actions workflow by removing the temporary suppression of Node.js deprecation warnings during test runs.

- Workflow configuration:
  * [`.github/workflows/app-test.yaml`](diffhunk://#diff-c743da9b5147c9cd2127c4ac8948207208a9f7cd19968d28ff6a6c20640fdadfL40-L45): Removed the `NODE_OPTIONS: --no-deprecation` environment variable, so deprecation warnings will now be visible in test output.